### PR TITLE
Make all MarkdownEngineConfig properties optional

### DIFF
--- a/src/markdown-engine.ts
+++ b/src/markdown-engine.ts
@@ -55,31 +55,31 @@ export interface MarkdownEngineOutput {
 }
 
 export interface MarkdownEngineConfig {
-  usePandocParser: boolean
-  breakOnSingleNewLine: boolean
-  enableTypographer: boolean
-  enableWikiLinkSyntax: boolean
-  wikiLinkFileExtension: string
-  enableExtendedTableSyntax: boolean
-  protocolsWhiteList: string
+  usePandocParser?: boolean
+  breakOnSingleNewLine?: boolean
+  enableTypographer?: boolean
+  enableWikiLinkSyntax?: boolean
+  wikiLinkFileExtension?: string
+  enableExtendedTableSyntax?: boolean
+  protocolsWhiteList?: string
   /**
    * "KaTeX", "MathJax", or "None"
    */
-  mathRenderingOption: string
-  mathInlineDelimiters: string[][]
-  mathBlockDelimiters: string[][]
-  codeBlockTheme: string
-  previewTheme: string
-  revealjsTheme: string
-  mermaidTheme: string
-  frontMatterRenderingOption: string 
-  imageFolderPath: string
-  printBackground: boolean
-  phantomPath: string 
-  pandocPath: string
-  pandocMarkdownFlavor: string 
-  pandocArguments: string[]
-  latexEngine: string
+  mathRenderingOption?: string
+  mathInlineDelimiters?: string[][]
+  mathBlockDelimiters?: string[][]
+  codeBlockTheme?: string
+  previewTheme?: string
+  revealjsTheme?: string
+  mermaidTheme?: string
+  frontMatterRenderingOption?: string
+  imageFolderPath?: string
+  printBackground?: boolean
+  phantomPath?: string
+  pandocPath?: string
+  pandocMarkdownFlavor?: string
+  pandocArguments?: string[]
+  latexEngine?: string
 }
 
 export interface HTMLTemplateOption {


### PR DESCRIPTION
Currently, i build a CLI tool and a docker image with this package. There I extend the `MarkdownEngineConfig` interface to be compatible with any changes to this interface in the future.
The problem is if I extend this interface and use in my implementation I came across the issue that all properties are required.
I think it is not necessary that all properties are marked required because if any property is not set it will be set to a default value.
