### PR TITLE
Add support for file extensions while running code chunks

### DIFF
--- a/src/code-chunk.ts
+++ b/src/code-chunk.ts
@@ -47,7 +47,8 @@ export async function run(content:string, fileDirectoryPath:string, options:obje
     args = [args]
   }
 
-  const savePath = path.resolve(fileDirectoryPath, Math.random().toString(36).substr(2, 9) + '_code_chunk')
+  const fileExtension = getFileExtension(cmd);
+  const savePath = path.resolve(fileDirectoryPath, Math.random().toString(36).substr(2, 9) + '_code_chunk' + fileExtension);
   content = content.replace(/\u00A0/g, ' ')
 
   if (cmd.match(/(la)?tex/) || cmd === 'pdflatex') {
@@ -132,4 +133,13 @@ except Exception:
       return resolve(data)
     })
   })
+}
+
+function  getFileExtension(language : string) : string {
+  switch(language) {
+    case 'go' :
+      return '.go';
+    default :
+      return ''
+  }
 }


### PR DESCRIPTION
Some languages like Golang needs the file extension to be .go for it to
run. This allows us to run code chunks of those languages.