### PR TITLE
Fix opening links with ampersand on Unix

### DIFF
--- a/src/utility.ts
+++ b/src/utility.ts
@@ -1,7 +1,7 @@
 import * as path from "path"
 import * as fs from "fs"
 import * as os from "os"
-import {exec} from "child_process"
+import {execFile} from "child_process"
 import * as child_process from "child_process"
 import * as less from "less"
 import * as mkdirp_ from "mkdirp"
@@ -128,7 +128,8 @@ export function openFile(filePath) {
   else
     cmd = 'xdg-open'
   
-  exec(`${cmd} ${filePath}`)
+  execFile(cmd, filePath)
+    
 }
 
 /**

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -128,7 +128,7 @@ export function openFile(filePath) {
   else
     cmd = 'xdg-open'
   
-  execFile(cmd, filePath)
+  execFile(cmd, [filePath])
     
 }
 


### PR DESCRIPTION
Currently `markdown-preview-enhanced` truncates URLs that include an "&" when opening them on Unix. This happens because they are launched via `mume.openFile`, which builds a command string of "xdg-open url", and an "&" in a command on Unix indicates that the preceding text should be run in the background, and the text after the "&" is executed as a separate command.

A good rule of thumb is to avoid building command strings by passing the components of the command separately. Luckily, `child_process` has an `execFile` function that allows us to do that. After this change, I am able to open these URLs correctly.