### PR TITLE
Add build:watch npm script and use it in .vscode/tasks.json 

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,9 +2,9 @@
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
     "version": "0.1.0",
-    "command": "tsc",
+    "command": "npm",
     "isShellCommand": true,
-    "args": ["-w", "-p", "."],
+    "args": ["run", "build:watch"],
     "showOutput": "silent",
     "isBackground": true,
     "problemMatcher": "$tsc-watch"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "typings": "out/src/mume.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "node_modules/.bin/tsc",
+    "build": "tsc -p .",
     "build:watch": "tsc -w -p .",
     "prepare": "npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "node_modules/.bin/tsc",
+    "build:watch": "tsc -w -p .",
     "prepare": "npm run build"
   },
   "files": [


### PR DESCRIPTION
Hey Yiyi! I cloned you repo to run one experiment on top of it and noticed that it was a bit hard to setup a continuous build  outside .vscode. I created an new npm script called `build:watch` and also rephrased `npm run build` for consistency. This makes the build process editor-agnostic and helps test the library locally in a downstream project.