### PR TITLE
Bugfix in conversion to pdf

### DIFF
--- a/src/pandoc-convert.ts
+++ b/src/pandoc-convert.ts
@@ -78,9 +78,9 @@ function processOutputConfig(config:object, args:string[], latexEngine:string='p
     args.push('-V', 'fonttheme:'+config['fonttheme'])
 
   if (config['latex_engine'])
-    args.push('--pdf-engine='+config['latex_engine'])
+    args.push('--latex-engine='+config['latex_engine'])
   else {
-    args.push('--pdf-engine='+latexEngine)
+    args.push('--latex-engine='+latexEngine)
   }
 
   if (config['includes'] && typeof(config['includes']) === 'object') {


### PR DESCRIPTION
Hi there,
pandoc help says that there is only the argument `--latex-engine` and no `--pdf-engine` argument. After changing the code to latex-engine i could successfully generate pdf documents with pandoc. 