### PR TITLE
Fixes Issue #46 - identifiers in ATX-style headings which contain a colon are no longer ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,10 +198,15 @@ const engine = new mume.MarkdownEngine({
 })
 ```
 
-
 ## Global Configuration
+
 Global config files are located at `~/.mume` directory
 
 ## Development
-[Visual Studio Code](https://code.visualstudio.com/) is recommended.    
-Clone this project, `npm install`, open in vscode, then `cmd+shift+b` to build.  
+
+[Visual Studio Code](https://code.visualstudio.com/) is recommended.
+
+1. Clone this project
+2. Run `npm install` from shell
+3. Open in vscode, then `cmd+shift+b` to build
+4. Run the tests with `npm run test`

--- a/src/lib/attributes/parse.ts
+++ b/src/lib/attributes/parse.ts
@@ -98,7 +98,7 @@ function extractQuotedString(text, start): Node | void {
   return [chars.join(""), end, NodeType.QUOTED_STRING];
 }
 
-const wordCharRegExp = /^[^,;=\s:]$/;
+const wordCharRegExp = /^[^,;=\s]$/;
 function extractWord(text: string, start: number): Node | void {
   let i = start;
   let bracketDepth = 0;

--- a/src/lib/attributes/parse.ts
+++ b/src/lib/attributes/parse.ts
@@ -37,7 +37,7 @@ export default function(text?: string): Attributes {
       if (keyIsPending) {
         output[pendingKey] = value;
         pendingKey = undefined;
-      } else if (textToParse[i] === "=" || textToParse[i] === ":") {
+      } else if (textToParse[i] === "=") {
         pendingKey = value;
       } else {
         const firstChar = value[0];

--- a/test/lib/attributes.test.ts
+++ b/test/lib/attributes.test.ts
@@ -62,6 +62,16 @@ const testCases: Array<{
     stringified: 'cmd=true id="some-id"',
   },
   {
+    attributes: { cmd: true, id: "some-id:with-colon" },
+    raw: "cmd=true #some-id:with-colon",
+    stringified: 'cmd=true id="some-id:with-colon"',
+  },
+  {
+    attributes: { id: "some-id:with-colon", class: "class1 class2", key1: "value1", key2: "value2"},
+    raw: "#some-id:with-colon .class1 .class2 key1=value1 key2=value2",
+    stringified: 'id="some-id:with-colon" class="class1 class2" key1="value1" key2="value2"',
+  },
+  {
     attributes: { cmd: true, id: "0" },
     raw: "cmd=true #0",
     stringified: 'cmd=true id="0"',

--- a/test/lib/attributes.test.ts
+++ b/test/lib/attributes.test.ts
@@ -13,18 +13,12 @@ const testCases: Array<{
   {
     // classic behavior
     attributes: { cmd: true },
-    raw: [
-      "cmd=true",
-      "{cmd=true}",
-      "  {  cmd=true  }  ",
-      "{cmd:true}",
-      "cmd:true",
-    ],
+    raw: ["cmd=true", "{cmd=true}", "  {  cmd=true  }  "],
     stringified: "cmd=true",
   },
   {
     attributes: { cmd: true, hello: "world" },
-    raw: ["cmd=true hello=world", "cmd:true hello:world"],
+    raw: "cmd=true hello=world",
     stringified: 'cmd=true hello="world"',
   },
   {


### PR DESCRIPTION
This also reverts https://github.com/shd101wyy/mume/commit/4898f1f1b077a725b0fa26f3830a06db51448357 although this is not the cause of the bug it would have made fixing it a bit messy.