### PR TITLE
Fixes Issue #50 - newline characters in math are now replaced by spaces

### DIFF
--- a/src/parse-math.ts
+++ b/src/parse-math.ts
@@ -44,7 +44,7 @@ export default ({
       return `<span style=\"color: #ee7f49; font-weight: 500;\">${error.toString()}</span>`;
     }
   } else if (renderingOption === "MathJax") {
-    const text = (openTag + content + closeTag).replace(/\n/g, "");
+    const text = (openTag + content + closeTag).replace(/\n/g, " ");
     const tag = displayMode ? "div" : "span";
     return `<${tag} class="mathjax-exps">${escapeString(text)}</${tag}>`;
   } else {


### PR DESCRIPTION
This resolves the problem with newline characters which was reported in Issue #50. The actual change is very simple as seen in the diff.  Thanks!
