### PR TITLE
[RFC] onUpdateLintingReport

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/jquery": "^3.2.6",
     "@types/markdown-it": "0.0.4",
     "@types/node": "^8.0.10",
+    "@types/vfile": "^2.2.2",
     "jest": "^22.4.0",
     "prettier": "^1.10.2",
     "prettier-check": "^2.0.0",

--- a/src/markdown-engine.ts
+++ b/src/markdown-engine.ts
@@ -5,6 +5,7 @@ import { execFile } from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 import * as request from "request";
+import { VFile } from "vfile";
 import * as YAML from "yamljs";
 
 import { CodeChunkData } from "./code-chunk-data";
@@ -126,6 +127,8 @@ let MODIFY_SOURCE: (
   filePath: string,
 ) => Promise<string> = null;
 
+let UPDATE_LINTING_REPORT: (vFiles: Array<VFile<{}>>) => void = null;
+
 /**
  * The markdown engine that can be used to parse markdown and export files
  */
@@ -162,6 +165,16 @@ export class MarkdownEngine {
     ) => Promise<string>,
   ) {
     MODIFY_SOURCE = cb;
+  }
+
+  public static async updateLintingReport(vFiles: Array<VFile<{}>>) {
+    if (UPDATE_LINTING_REPORT) {
+      await UPDATE_LINTING_REPORT(vFiles);
+    }
+  }
+
+  public static onUpdateLintingReport(cb: (vFiles: Array<VFile<{}>>) => void) {
+    UPDATE_LINTING_REPORT = cb;
   }
 
   /**

--- a/src/markdown-engine.ts
+++ b/src/markdown-engine.ts
@@ -31,10 +31,9 @@ import enhanceWithEmbeddedLocalImages from "./render-enhancers/embedded-local-im
 import enhanceWithEmbeddedSvgs from "./render-enhancers/embedded-svgs";
 import enhanceWithExtendedTableSyntax from "./render-enhancers/extended-table-syntax";
 import enhanceWithFencedCodeChunks, {
-/* tslint:disable-next-line:ordered-imports */
-  runCodeChunks,
   runCodeChunk,
   RunCodeChunkOptions,
+  runCodeChunks,
 } from "./render-enhancers/fenced-code-chunks";
 import enhanceWithFencedDiagrams from "./render-enhancers/fenced-diagrams";
 import enhanceWithFencedMath from "./render-enhancers/fenced-math";
@@ -304,7 +303,10 @@ export class MarkdownEngine {
     this.enableTypographer = this.config.enableTypographer;
 
     // protocal whitelist
-    const protocolsWhiteList = (this.config.protocolsWhiteList || defaultMarkdownEngineConfig.protocolsWhiteList)
+    const protocolsWhiteList = (
+      this.config.protocolsWhiteList ||
+      defaultMarkdownEngineConfig.protocolsWhiteList
+    )
       .split(",")
       .map((x) => x.trim());
     this.protocolsWhiteListRegExp = new RegExp(

--- a/src/render-enhancers/code-block-styling.ts
+++ b/src/render-enhancers/code-block-styling.ts
@@ -1,7 +1,7 @@
 import { resolve } from "path";
 import { scopeForLanguageName } from "../extension-helper";
 import { BlockInfo } from "../lib/block-info";
-import { extensionDirectoryPath, escapeString } from "../utility";
+import { escapeString, extensionDirectoryPath } from "../utility";
 
 let Prism;
 

--- a/test/integration/fixtures/basics.md
+++ b/test/integration/fixtures/basics.md
@@ -30,16 +30,16 @@ console.log(greeting);
 `js .line-numbers`
 
 ```js .line-numbers
-var greeting = 'Hello world!';
+var greeting = "Hello world!";
 console.log(greeting);
 
-var greeting2 = 'Hello world2!';
+var greeting2 = "Hello world2!";
 console.log(greeting2);
 
-var greeting3 = 'Hello world3!';
+var greeting3 = "Hello world3!";
 console.log(greeting3);
 
-var greeting4 = 'Hello world4!';
+var greeting4 = "Hello world4!";
 console.log(greeting4);
 ```
 
@@ -56,7 +56,7 @@ this should not be seen
 `js {cmd=false}`
 
 ```js {cmd=false}
-var greeting = 'Hello world!';
+var greeting = "Hello world!";
 console.log(greeting);
 ```
 
@@ -65,6 +65,6 @@ console.log(greeting);
 `js {literate=false}`
 
 ```js {literate=false}
-var greeting = 'Hello world!';
+var greeting = "Hello world!";
 console.log(greeting);
 ```

--- a/test/integration/fixtures/code-chunks.md
+++ b/test/integration/fixtures/code-chunks.md
@@ -29,8 +29,8 @@ ls .
 `js {cmd=node output=html}`
 
 ```js {cmd=node output=html}
-const date = Date.now()
-console.log(date.toString())
+const date = Date.now();
+console.log(date.toString());
 ```
 
 ---
@@ -38,7 +38,7 @@ console.log(date.toString())
 `js {cmd=node output=markdown}`
 
 ```js {cmd=node output=markdown}
-var greeting = 'Hello _world_';
+var greeting = "Hello _world_";
 console.log(greeting);
 ```
 
@@ -47,7 +47,7 @@ console.log(greeting);
 `js {cmd=node output=markdown output_first}`
 
 ```js {cmd=node output=markdown output_first}
-var greeting = 'Hello _world_';
+var greeting = "Hello _world_";
 console.log(greeting);
 ```
 
@@ -56,7 +56,7 @@ console.log(greeting);
 `js {cmd=node output=none}`
 
 ```js {cmd=node output=none}
-var greeting = 'Hello world!';
+var greeting = "Hello world!";
 console.log(greeting);
 ```
 
@@ -65,7 +65,7 @@ console.log(greeting);
 `js {cmd=node output=txt modify_source}`
 
 ```js {cmd=node output=txt modify_source}
-var greeting = 'Hello world!';
+var greeting = "Hello world!";
 console.log(greeting);
 ```
 
@@ -74,7 +74,7 @@ console.log(greeting);
 `js {cmd=node output=txt modify_source run_on_save}`
 
 ```js {cmd=node output=txt modify_source run_on_save}
-var greeting = 'Hello world!!!';
+var greeting = "Hello world!!!";
 console.log(greeting);
 ```
 
@@ -135,8 +135,8 @@ print(x) # will print 1
 `js {cmd=node output=text .line-numbers}`
 
 ```js {cmd=node output=text .line-numbers}
-const date = Date.now()
-console.log(date.toString())
+const date = Date.now();
+console.log(date.toString());
 ```
 
 ---


### PR DESCRIPTION
Hi @shd101wyy!

I'm submitting this PR as a first step towards merging [litvis](https://github.com/gicentre/litvis) into mume. This potential future merge will improve mume's functionality and also avoid a need to maintain a [fork of mume](https://github.com/gicentre/mume-with-litvis).

`MarkdowEngine.onUpdateLintingReport()` makes it possible for render enhancers to report any issues with the input file and thus have them displayed in the Editor's GUI. [For instance](https://github.com/gicentre/litvis#linting):

![](https://user-images.githubusercontent.com/608862/38143955-bc310866-343a-11e8-94f8-c31a71e6155c.gif)

This PR does not add any new functionality – the method is just a placeholder for a possible future use.

I implemented `onUpdateLintingReport` similarly to how `onModifySource` works, but I'm open to refactor it if you're keen. It might be worth making both methods non-static, but I'm not sure – there might be a reason behind your design that I simply don't see.
