### PR TITLE
Fixes for spaces in paths/PATHEXT for windows.

### DIFF
--- a/src/latex.ts
+++ b/src/latex.ts
@@ -45,8 +45,9 @@ export function toSVGMarkdown(
   },
 ): Promise<string> {
   return new Promise<string>((resolve, reject) => {
-    const task = spawn(latexEngine, [texFilePath], {
+    const task = spawn(latexEngine, [`"${texFilePath}"`], {
       cwd: path.dirname(texFilePath),
+      shell: true,
     });
 
     const chunks = [];

--- a/src/markdown-engine.ts
+++ b/src/markdown-engine.ts
@@ -1358,10 +1358,10 @@ for (var i = 0; i < flowcharts.length; i++) {
       sidebarTOCScript = `
 <script>
 ${
-        yamlConfig["html"] && yamlConfig["html"]["toc"]
-          ? `document.body.setAttribute('html-show-sidebar-toc', true)`
-          : ""
-      }
+  yamlConfig["html"] && yamlConfig["html"]["toc"]
+    ? `document.body.setAttribute('html-show-sidebar-toc', true)`
+    : ""
+}
 var sidebarTOCBtn = document.getElementById('sidebar-toc-btn')
 sidebarTOCBtn.addEventListener('click', function(event) {
   event.stopPropagation()

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -37,10 +37,10 @@ export function toSVGMarkdown(
     const svgFilePrefix = computeChecksum(pdfFilePath) + "_";
 
     const task = spawn("pdf2svg", [
-      pdfFilePath,
-      path.resolve(svgDirectoryPath, svgFilePrefix + "%d.svg"),
+      `"${pdfFilePath}"`,
+      `"${path.resolve(svgDirectoryPath, svgFilePrefix + "%d.svg")}"`,
       "all",
-    ]);
+    ], {shell: True});
     const chunks = [];
     task.stdout.on("data", (chunk) => {
       chunks.push(chunk);

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -36,11 +36,15 @@ export function toSVGMarkdown(
 
     const svgFilePrefix = computeChecksum(pdfFilePath) + "_";
 
-    const task = spawn("pdf2svg", [
-      `"${pdfFilePath}"`,
-      `"${path.resolve(svgDirectoryPath, svgFilePrefix + "%d.svg")}"`,
-      "all",
-    ], {shell: true});
+    const task = spawn(
+      "pdf2svg",
+      [
+        `"${pdfFilePath}"`,
+        `"${path.resolve(svgDirectoryPath, svgFilePrefix + "%d.svg")}"`,
+        "all",
+      ],
+      { shell: true },
+    );
     const chunks = [];
     task.stdout.on("data", (chunk) => {
       chunks.push(chunk);

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -40,7 +40,7 @@ export function toSVGMarkdown(
       `"${pdfFilePath}"`,
       `"${path.resolve(svgDirectoryPath, svgFilePrefix + "%d.svg")}"`,
       "all",
-    ], {shell: True});
+    ], {shell: true});
     const chunks = [];
     task.stdout.on("data", (chunk) => {
       chunks.push(chunk);
@@ -86,8 +86,8 @@ export function toSVGMarkdown(
               // nvm, the converted result looks so ugly
               /*
             const pngFilePath = svgFilePath.replace(/\.svg$/, '.png')
-            
-            // convert svg to png 
+
+            // convert svg to png
             gm(svgFilePath)
             .noProfile()
             .write(pngFilePath, function(error) {


### PR DESCRIPTION
I use `mume` through the Markdown preview enhanced extension for VS Code. Recently I wanted to embed some LaTeX blocks in my markdown files, but I had a bit of trouble generating the outputs properly. There are a couple of small fixes in this PR that made everything work for me:

1. In `latex.ts` and `pdf.ts`, I've wrapped the paths for the .tex/.pdf/.svg files in double quotes so that (as is not uncommon in Windows) there won't be errors if these paths have spaces in them.

2. I added the `shell = true` argument to `spawn` in the same two files because otherwise it does not respect the `PATHEXT` environment variable on Windows which can lead it to throw ENOENT errors for commands that would work on the command line. This is probably a niche case here (I only have this problem because, e.g., my `pdflatex` is actually `pdflatex.py`; I have a custom wrapper), but I think it would still be nice to include if `shell = true` doesn't have any significant downsides (I'm not much of a Javascript/Node developer, so I don't have experience with this). [`cross-spawn`][cross-spawn] is a variant of `child_process` that does respect `PATHEXT`, among a few other fixes, but I thought it would be easier to just use `shell = true` than requiring a different library.

[cross-spawn]: https://github.com/moxystudio/node-cross-spawn