### PR TITLE
Fix for ImageMagick 'convert' command issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "cheerio": "^1.0.0-rc.2",
     "fs-extra": "^7.0.1",
     "gray-matter": "^4.0.1",
+    "imagemagick-cli": "^0.3.0",
     "less": "^3.9.0",
     "lodash": "^4.17.5",
     "mkdirp": "^0.5.1",

--- a/src/magick.ts
+++ b/src/magick.ts
@@ -1,7 +1,9 @@
 /**
  * ImageMagick magick command wrapper
  */
-import { execFile, tempOpen, write } from "./utility";
+import imagemagickCli from "imagemagick-cli";
+
+import { tempOpen, write } from "./utility";
 
 export async function svgElementToPNGFile(
   svgElement: string,
@@ -9,13 +11,12 @@ export async function svgElementToPNGFile(
 ): Promise<string> {
   const info = await tempOpen({ prefix: "mume-svg", suffix: ".svg" });
   await write(info.fd, svgElement); // write svgElement to temp .svg file
+  const args = [info.path, pngFilePath];
   try {
-    await execFile("convert", [info.path, pngFilePath]);
+    await imagemagickCli.exec(`convert ${args.join(" ")}`);
   } catch (error) {
-    throw new Error(
-      "ImageMagick is required to be installed to convert svg to png.\n" +
-        error.toString(),
-    );
+    throw new Error("imagemagick-cli failure\n" + error.toString());
   }
+
   return pngFilePath;
 }


### PR DESCRIPTION
* Fix ImageMagick command issue. Change from execFile('convert') to multiplatform imagemagick-cli('convert') 
* Fixes #96 

In magick.ts which is a wrapper for ImageMagick, was used execFile("convert"), which was causing issues on Windows, due to Windows Convert tool. This is fixed by replacing execFile convert with multiplatform [imagemagick-cli](https://www.npmjs.com/package/imagemagick-cli).