### PR TITLE
Allow to choose online math rendering service

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ const config = {
   mathRenderingOption: "KaTeX",  // "KaTeX" | "MathJax" | "None"
   mathInlineDelimiters: [["$", "$"], ["\\(", "\\)"]],
   mathBlockDelimiters: [["$$", "$$"], ["\\[", "\\]"]],
+  mathRenderingOnLineService: "https://latex.codecogs.com/gif.latex", // "https://latex.codecogs.com/svg.latex", "https://latex.codecogs.com/png.latex"
 
   // Enable Wiki Link syntax support. More information can be found a  https://help.github.com/articles/adding-links-to-wikis/
   enableWikiLinkSyntax: true,

--- a/src/markdown-convert.ts
+++ b/src/markdown-convert.ts
@@ -19,7 +19,7 @@ import * as utility from "./utility";
  */
 function processMath(
   text: string,
-  { mathInlineDelimiters, mathBlockDelimiters },
+  { mathInlineDelimiters, mathBlockDelimiters, mathRenderingOnLineService },
 ): string {
   let line = text.replace(/\\\$/g, "#slash_dollarsign#");
 
@@ -72,7 +72,7 @@ function processMath(
       let math = $2;
       math = math.replace(/\n/g, "").replace(/\#slash\_dollarsign\#/g, "\\$");
       math = utility.escapeString(math);
-      return `<p align="center"><img src=\"https://latex.codecogs.com/gif.latex?${math
+      return `<p align="center"><img src=\"${mathRenderingOnLineService}?${math
         .trim()
         .replace(/ /g, "%20")}\"/></p>  \n`;
     },
@@ -91,7 +91,7 @@ function processMath(
       let math = $2;
       math = math.replace(/\n/g, "").replace(/\#slash\_dollarsign\#/g, "\\$");
       math = utility.escapeString(math);
-      return `<img src=\"https://latex.codecogs.com/gif.latex?${math
+      return `<img src=\"${mathRenderingOnLineService}?${math
         .trim()
         .replace(/ /g, "%20")}\"/>`;
     },
@@ -181,6 +181,7 @@ export async function markdownConvert(
     filesCache,
     mathInlineDelimiters,
     mathBlockDelimiters,
+    mathRenderingOnLineService,
     codeChunksData,
     graphsCache,
     usePandocParser,
@@ -191,6 +192,7 @@ export async function markdownConvert(
     filesCache: { [key: string]: string };
     mathInlineDelimiters: string[][];
     mathBlockDelimiters: string[][];
+    mathRenderingOnLineService: string,
     codeChunksData: { [key: string]: CodeChunkData };
     graphsCache: { [key: string]: string };
     usePandocParser: boolean;
@@ -260,7 +262,7 @@ export async function markdownConvert(
   }
 
   // change link path to project '/' path
-  // this is actually differnet from pandoc-convert.coffee
+  // this is actually different from pandoc-convert.coffee
   text = processPaths(
     text,
     fileDirectoryPath,
@@ -269,7 +271,7 @@ export async function markdownConvert(
     protocolsWhiteListRegExp,
   );
 
-  text = processMath(text, { mathInlineDelimiters, mathBlockDelimiters });
+  text = processMath(text, { mathInlineDelimiters, mathBlockDelimiters, mathRenderingOnLineService });
 
   return await new Promise<string>((resolve, reject) => {
     mkdirp(imageDirectoryPath, (error, made) => {

--- a/src/markdown-convert.ts
+++ b/src/markdown-convert.ts
@@ -192,7 +192,7 @@ export async function markdownConvert(
     filesCache: { [key: string]: string };
     mathInlineDelimiters: string[][];
     mathBlockDelimiters: string[][];
-    mathRenderingOnLineService: string,
+    mathRenderingOnLineService: string;
     codeChunksData: { [key: string]: CodeChunkData };
     graphsCache: { [key: string]: string };
     usePandocParser: boolean;
@@ -271,7 +271,11 @@ export async function markdownConvert(
     protocolsWhiteListRegExp,
   );
 
-  text = processMath(text, { mathInlineDelimiters, mathBlockDelimiters, mathRenderingOnLineService });
+  text = processMath(text, {
+    mathInlineDelimiters,
+    mathBlockDelimiters,
+    mathRenderingOnLineService,
+  });
 
   return await new Promise<string>((resolve, reject) => {
     mkdirp(imageDirectoryPath, (error, made) => {

--- a/src/markdown-engine-config.ts
+++ b/src/markdown-engine-config.ts
@@ -14,6 +14,7 @@ export interface MarkdownEngineConfig {
   mathRenderingOption?: MathRenderingOption;
   mathInlineDelimiters?: string[][];
   mathBlockDelimiters?: string[][];
+  mathRenderingOnLineService?: string;
   codeBlockTheme?: string;
   previewTheme?: string;
   revealjsTheme?: string;
@@ -43,6 +44,7 @@ export const defaultMarkdownEngineConfig: MarkdownEngineConfig = {
   mathRenderingOption: "KaTeX",
   mathInlineDelimiters: [["$", "$"], ["\\(", "\\)"]],
   mathBlockDelimiters: [["$$", "$$"], ["\\[", "\\]"]],
+  mathRenderingOnLineService: "https://latex.codecogs.com/gif.latex",
   codeBlockTheme: "auto.css",
   previewTheme: "github-light.css",
   revealjsTheme: "white.css",

--- a/src/markdown-engine.ts
+++ b/src/markdown-engine.ts
@@ -2350,7 +2350,7 @@ sidebarTOCBtn.addEventListener('click', function(event) {
      * markdownConfig has the following properties:
      *     path:                        destination of the output file
      *     image_dir:                   where to save the image file
-     *     use_abolute_image_path:      as the name shows.
+     *     use_absolute_image_path:      as the name shows.
      *     ignore_from_front_matter:    default is true.
      */
     let markdownConfig = {};
@@ -2400,6 +2400,7 @@ sidebarTOCBtn.addEventListener('click', function(event) {
         filesCache: this.filesCache,
         mathInlineDelimiters: this.config.mathInlineDelimiters,
         mathBlockDelimiters: this.config.mathBlockDelimiters,
+        mathRenderingOnLineService: this.config.mathRenderingOnLineService,
         codeChunksData: this.codeChunksData,
         graphsCache: this.graphsCache,
         usePandocParser: this.config.usePandocParser,


### PR DESCRIPTION
Allow to set the on line service to render math expressions.
The new configuration parameter is optional and defaults to gif, to not break compatibility.

See also : https://github.com/shd101wyy/vscode-markdown-preview-enhanced/pull/204