### PR TITLE
Allow to use mathRenderingOption: "None" while rendering to markdown

### DIFF
--- a/src/markdown-convert.ts
+++ b/src/markdown-convert.ts
@@ -179,6 +179,7 @@ export async function markdownConvert(
     fileDirectoryPath,
     protocolsWhiteListRegExp,
     filesCache,
+    mathRenderingOption,
     mathInlineDelimiters,
     mathBlockDelimiters,
     mathRenderingOnlineService,
@@ -190,6 +191,7 @@ export async function markdownConvert(
     fileDirectoryPath: string;
     protocolsWhiteListRegExp: RegExp;
     filesCache: { [key: string]: string };
+    mathRenderingOption: string;
     mathInlineDelimiters: string[][];
     mathBlockDelimiters: string[][];
     mathRenderingOnlineService: string;
@@ -271,11 +273,14 @@ export async function markdownConvert(
     protocolsWhiteListRegExp,
   );
 
-  text = processMath(text, {
-    mathInlineDelimiters,
-    mathBlockDelimiters,
-    mathRenderingOnlineService,
-  });
+  text =
+    mathRenderingOption !== "None"
+      ? processMath(text, {
+          mathInlineDelimiters,
+          mathBlockDelimiters,
+          mathRenderingOnlineService,
+        })
+      : text;
 
   return await new Promise<string>((resolve, reject) => {
     mkdirp(imageDirectoryPath, (error, made) => {

--- a/src/markdown-engine.ts
+++ b/src/markdown-engine.ts
@@ -2286,6 +2286,7 @@ sidebarTOCBtn.addEventListener('click', function(event) {
         fileDirectoryPath: this.fileDirectoryPath,
         protocolsWhiteListRegExp: this.protocolsWhiteListRegExp,
         filesCache: this.filesCache,
+        mathRenderingOption: this.config.mathRenderingOption,
         mathInlineDelimiters: this.config.mathInlineDelimiters,
         mathBlockDelimiters: this.config.mathBlockDelimiters,
         mathRenderingOnlineService: this.config.mathRenderingOnlineService,


### PR DESCRIPTION
This little patch allows specifying `mathRenderingOption: "None"` while rendering to markdown and thus doesn't leave this option without notice by markdown convert process.