### PR TITLE
Pandoc fixes

### DIFF
--- a/src/markdown-engine.ts
+++ b/src/markdown-engine.ts
@@ -2575,7 +2575,7 @@ sidebarTOCBtn.addEventListener('click', function(event) {
     text: string = "",
     args: string[],
   ): Promise<string> {
-    var mathRenderer;
+    let mathRenderer;
     switch (this.config.mathRenderingOption) {
       case "MathJax":
         mathRenderer = "--mathjax";

--- a/src/markdown-engine.ts
+++ b/src/markdown-engine.ts
@@ -500,7 +500,7 @@ export class MarkdownEngine {
 ${utility.configs.mermaidConfig}
 if (window['MERMAID_CONFIG']) {
   window['MERMAID_CONFIG'].startOnLoad = false
-  window['MERMAID_CONFIG'].cloneCssStyles = false 
+  window['MERMAID_CONFIG'].cloneCssStyles = false
   window['MERMAID_CONFIG'].theme = "${this.config.mermaidTheme}"
 }
 mermaid.initialize(window['MERMAID_CONFIG'] || {})
@@ -982,7 +982,7 @@ if (typeof(window['Reveal']) !== 'undefined') {
         )}">
 
         ${this.generateJSAndCssFilesForPreview(JSAndCssFiles, isForVSCode)}
-        ${head}        
+        ${head}
       </head>
       <body class="preview-container">
         <div class="mume markdown-preview" for="preview" ${
@@ -1495,7 +1495,7 @@ sidebarTOCBtn.addEventListener('click', function(event) {
       ${mathStyle}
       ${sequenceDiagramStyle}
       ${fontAwesomeStyle}
-      
+
       ${presentationScript}
       ${mermaidScript}
       ${wavedromScript}
@@ -1503,8 +1503,8 @@ sidebarTOCBtn.addEventListener('click', function(event) {
       ${flowchartScript}
       ${sequenceDiagramScript}
 
-      <style> 
-      ${styles} 
+      <style>
+      ${styles}
       </style>
     </head>
     <body ${options.isForPrint ? "" : 'for="html-export"'} ${
@@ -2087,9 +2087,9 @@ sidebarTOCBtn.addEventListener('click', function(event) {
     <title>${title}</title>
     <meta charset=\"utf-8\">
     <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">
-    <style> 
-    ${styleCSS} 
-    ${globalStyles} 
+    <style>
+    ${styleCSS}
+    ${globalStyles}
     </style>
     ${mathStyle}
   </head>
@@ -2098,7 +2098,7 @@ sidebarTOCBtn.addEventListener('click', function(event) {
     ${outputHTML}
     </div>
   </body>
-</html>            
+</html>
 `;
 
     // save as html
@@ -2575,13 +2575,22 @@ sidebarTOCBtn.addEventListener('click', function(event) {
     text: string = "",
     args: string[],
   ): Promise<string> {
+    var mathRenderer;
+    switch (this.config.mathRenderingOption) {
+      case "MathJax":
+        mathRenderer = "--mathjax";
+        break;
+      case "KaTeX":
+        mathRenderer = "--katex";
+        break;
+      default:
+        mathRenderer = "";
+    }
     args = args || [];
     args = [
-      "-f",
-      this.config.pandocMarkdownFlavor, // -tex_math_dollars doesn't work properly
-      "-t",
-      "html",
-      "--mathjax",
+      "--from=" + this.config.pandocMarkdownFlavor, // -tex_math_dollars doesn't work properly
+      "--to=html",
+      mathRenderer,
     ]
       .concat(args)
       .filter((arg) => arg.length);

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -348,9 +348,9 @@ export async function transformMarkdown(
         }
         /* tslint:disable-next-line:no-conditional-assignment */
       } else if ((headingMatch = line.match(/^(\#{1,7})(.+)/))) {
-        /* ((headingMatch = line.match(/^(\#{1,7})(.+)$/)) || 
-                  // the ==== and --- headers don't work well. For example, table and list will affect it, therefore I decide not to support it.  
-                  (inputString[end + 1] === '=' && inputString[end + 2] === '=') || 
+        /* ((headingMatch = line.match(/^(\#{1,7})(.+)$/)) ||
+                  // the ==== and --- headers don't work well. For example, table and list will affect it, therefore I decide not to support it.
+                  (inputString[end + 1] === '=' && inputString[end + 2] === '=') ||
                   (inputString[end + 1] === '-' && inputString[end + 2] === '-')) */ // headings
 
         if (forPreview) {
@@ -371,9 +371,9 @@ export async function transformMarkdown(
             } else {
               heading = line.trim()
               tag = '##'
-              level = 2     
+              level = 2
             }
-            
+
             end = inputString.indexOf('\n', end + 1)
             if (end < 0) end = inputString.length
           }*/
@@ -391,15 +391,19 @@ export async function transformMarkdown(
         let classes = "";
         let id = "";
         let ignore = false;
+        var opt;
         if (optMatch) {
           heading = heading.replace(optMatch[0], "");
 
           try {
-            const opt = parseAttributes(optMatch[0]);
+            opt = parseAttributes(optMatch[0]);
 
             (classes = opt["class"]),
               (id = opt["id"]),
               (ignore = opt["ignore"]);
+            delete opt["class"];
+            delete opt["id"];
+            delete opt["ignore"];
           } catch (e) {
             heading = "OptionsError: " + optMatch[1];
             ignore = true;
@@ -428,6 +432,15 @@ export async function transformMarkdown(
           }
           if (classes) {
             optionsStr += "." + classes.replace(/\s+/g, " .") + " ";
+          }
+          if (opt) {
+            for (var key in opt) {
+              if (typeof opt[key] === "number") {
+                optionsStr += " " + key + "=" + opt[key];
+              } else {
+                optionsStr += " " + key + '="' + opt[key] + '"';
+              }
+            }
           }
           optionsStr += "}";
 
@@ -884,7 +897,7 @@ export async function transformMarkdown(
               else if extname in ['.wavedrom']
                 output = "```wavedrom\n${fileContent}\n```  "
                 # filesCache?[absoluteFilePath] = output
-              
+
               else if extname == '.js'
                 if forPreview
                   output = '' # js code is evaluated and there is no need to display the code.

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -347,7 +347,7 @@ export async function transformMarkdown(
           outputString += createAnchor(lineNo); // insert anchor for scroll sync
         }
         /* tslint:disable-next-line:no-conditional-assignment */
-      } else if ((headingMatch = line.match(/^(\#{1,7})(.+)/))) {
+      } else if ((headingMatch = line.match(/^(\#{1,7}).*/))) {
         /* ((headingMatch = line.match(/^(\#{1,7})(.+)$/)) ||
                   // the ==== and --- headers don't work well. For example, table and list will affect it, therefore I decide not to support it.
                   (inputString[end + 1] === '=' && inputString[end + 2] === '=') ||
@@ -360,7 +360,7 @@ export async function transformMarkdown(
         let level;
         let tag;
         // if (headingMatch) {
-        heading = headingMatch[2].trim();
+        heading = line.replace(headingMatch[1],"")
         tag = headingMatch[1];
         level = tag.length;
         /*} else {
@@ -378,13 +378,13 @@ export async function transformMarkdown(
             if (end < 0) end = inputString.length
           }*/
 
-        if (!heading.length) {
+        /*if (!heading.length) {
           // return helper(end+1, lineNo+1, outputString + '\n')
           i = end + 1;
           lineNo = lineNo + 1;
           outputString = outputString + "\n";
           continue;
-        }
+        }*/
 
         // check {class:string, id:string, ignore:boolean}
         const optMatch = heading.match(/([^\\]\{|^\{)(.+?)\}(\s*)$/);

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -360,7 +360,7 @@ export async function transformMarkdown(
         let level;
         let tag;
         // if (headingMatch) {
-        heading = line.replace(headingMatch[1],"")
+        heading = line.replace(headingMatch[1], "");
         tag = headingMatch[1];
         level = tag.length;
         /*} else {

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -391,7 +391,7 @@ export async function transformMarkdown(
         let classes = "";
         let id = "";
         let ignore = false;
-        var opt;
+        let opt;
         if (optMatch) {
           heading = heading.replace(optMatch[0], "");
 
@@ -434,7 +434,7 @@ export async function transformMarkdown(
             optionsStr += "." + classes.replace(/\s+/g, " .") + " ";
           }
           if (opt) {
-            for (var key in opt) {
+            for (const key in opt) {
               if (typeof opt[key] === "number") {
                 optionsStr += " " + key + "=" + opt[key];
               } else {

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -387,7 +387,7 @@ export async function transformMarkdown(
         }
 
         // check {class:string, id:string, ignore:boolean}
-        const optMatch = heading.match(/[^\\]\{(.+?)\}(\s*)$/);
+        const optMatch = heading.match(/([^\\]\{|^\{)(.+?)\}(\s*)$/);
         let classes = "";
         let id = "";
         let ignore = false;


### PR DESCRIPTION
Fixes to get pandoc documents correctly displayed (as in other available markdown preview packages) when using:

- math renderers
- section attributes (needed f.e. when using pandoc-crossref)
- headers with empty text (f.e. useful when using pandoc-crossref)


