### PR TITLE
Change ditaa rendering png to svg (#162)

### DIFF
--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -20,7 +20,7 @@ I managed many libraries by myself instead of through npm to reduce overall file
   "vega": "5.9.0",
   "vega-lite": "4.0.2",
   "vega-embed": "6.2.1",
-  "ditaa": "0.10",
+  "ditaa": "0.11",
   "font-awesome": "4.7",
   "flowchart": "1.11.3",
   "raphael.js": "2.2.7",

--- a/src/ditaa.ts
+++ b/src/ditaa.ts
@@ -37,7 +37,7 @@ export async function render(
       dest = (
         await utility.tempOpen({
           prefix: "mume_ditaa",
-          suffix: ".png",
+          suffix: ".svg",
         })
       ).path;
     }
@@ -62,6 +62,7 @@ export async function render(
         ),
         info.path,
         dest,
+        "--svg",
       ].concat(args),
     );
     const outputDest = dest + "?" + Math.random();

--- a/src/render-enhancers/fenced-diagrams.ts
+++ b/src/render-enhancers/fenced-diagrams.ts
@@ -205,20 +205,19 @@ async function renderDiagram(
         const args = normalizedInfo.attributes["args"] || [];
         const filename =
           normalizedInfo.attributes["filename"] ||
-          `${computeChecksum(`${JSON.stringify(args)} ${code}`)}.png`;
+          `${computeChecksum(`${JSON.stringify(args)} ${code}`)}.svg`;
         await mkdirp(imageDirectoryPath);
 
-        const pathToPng = await renderDitaa(
+        const pathToSvg = await renderDitaa(
           code,
           args,
           resolve(imageDirectoryPath, filename),
         );
-        const pathToPngWithoutVersion = pathToPng.replace(/\?[\d\.]+$/, "");
-        const pngAsBase64 = await readFile(pathToPngWithoutVersion, "base64");
-        $output = $("<img />").attr(
-          "src",
-          `data:image/png;charset=utf-8;base64,${pngAsBase64}`,
-        );
+        const pathToSvgWithoutVersion = pathToSvg.replace(/\?[\d\.]+$/, "");
+        const svg = await readFile(pathToSvgWithoutVersion);
+        $output = `<p ${stringifyAttributes(
+          normalizedInfo.attributes,
+        )}>${svg}</p>`;
         break;
       }
     }


### PR DESCRIPTION
Close #162 

This change make package **large (about +10MB)** in size.

Update ditaa version from 0.10 to 0.11.
And change rendering output format from png to svg.

Ver 0.11 may have bug in shadows  between objects.
There are a few differences between png and svg ouputs.