### PR TITLE
Add diagram support on export

### DIFF
--- a/src/ditaa.ts
+++ b/src/ditaa.ts
@@ -43,7 +43,7 @@ export async function render(code: string = "", args = []): Promise<string> {
     const checksum = computeChecksum(codes);
 
     if (
-      dest in CACHE &&
+      checksum in CACHE &&
       CACHE[checksum].code === code &&
       utility.isArrayEqual(args, CACHE[checksum].args)
     ) {

--- a/src/markdown-convert.ts
+++ b/src/markdown-convert.ts
@@ -187,6 +187,7 @@ export async function markdownConvert(
     graphsCache,
     usePandocParser,
     imageMagickPath,
+    mermaidTheme,
   }: {
     projectDirectoryPath: string;
     fileDirectoryPath: string;
@@ -200,6 +201,7 @@ export async function markdownConvert(
     graphsCache: { [key: string]: string };
     usePandocParser: boolean;
     imageMagickPath: string;
+    mermaidTheme: string;
   },
   config: object,
 ): Promise<string> {
@@ -299,6 +301,7 @@ export async function markdownConvert(
         codeChunksData,
         graphsCache,
         imageMagickPath,
+        mermaidTheme,
       }).then(({ outputString }) => {
         outputString = data.frontMatterString + outputString; // put the front-matter back.
 

--- a/src/markdown-engine.ts
+++ b/src/markdown-engine.ts
@@ -2240,6 +2240,7 @@ sidebarTOCBtn.addEventListener('click', function(event) {
         pandocPath: this.config.pandocPath,
         latexEngine: this.config.latexEngine,
         imageMagickPath: this.config.imageMagickPath,
+        mermaidTheme: this.config.mermaidTheme,
       },
       config,
     );
@@ -2342,6 +2343,7 @@ sidebarTOCBtn.addEventListener('click', function(event) {
         graphsCache: this.graphsCache,
         usePandocParser: this.config.usePandocParser,
         imageMagickPath: this.config.imageMagickPath,
+        mermaidTheme: this.config.mermaidTheme,
       },
       markdownConfig,
     );

--- a/src/mermaid.ts
+++ b/src/mermaid.ts
@@ -1,47 +1,46 @@
 /**
  * A wrapper of mermaid CLI
- * http://knsv.github.io/mermaid/#mermaid-cli
+ * https://github.com/mermaid-js/mermaid.cli
  * But it doesn't work well
  */
-
-import * as fs from "fs";
-import * as path from "path";
 
 import * as utility from "./utility";
 
 export async function mermaidToPNG(
   mermaidCode: string,
   pngFilePath: string,
-  css = "mermaid.css",
+  projectDirectoryPath: string,
+  themeName,
 ): Promise<string> {
   const info = await utility.tempOpen({
     prefix: "mume-mermaid",
-    suffix: ".mermaid",
+    suffix: ".mmd",
   });
   await utility.write(info.fd, mermaidCode);
+  if (!themeName) {
+    themeName = "null";
+  }
   try {
-    await utility.execFile("mermaid", [
-      info.path,
-      "-p",
-      "-o",
-      path.dirname(info.path),
-      "--css",
-      path.resolve(
-        utility.extensionDirectoryPath,
-        "./dependencies/mermaid/" + css,
-      ),
-    ]);
-    // console.log(info.path);
-    fs.createReadStream(info.path + ".png").pipe(
-      fs.createWriteStream(pngFilePath),
+    await utility.execFile(
+      "npx",
+      [
+        "mmdc",
+        "--theme",
+        themeName,
+        "--input",
+        info.path,
+        "--output",
+        pngFilePath,
+      ],
+      {
+        shell: true,
+        cwd: projectDirectoryPath,
+      },
     );
-    fs.unlink(info.path + ".png", () => {
-      /**/
-    });
     return pngFilePath;
   } catch (error) {
     throw new Error(
-      "mermaid CLI is required to be installed.\nCheck http://knsv.github.io/mermaid/#mermaid-cli for more information.\n\n" +
+      "mermaid CLI is required to be installed.\nCheck https://github.com/mermaid-js/mermaid.cli for more information.\n\n" +
         error.toString(),
     );
   }

--- a/src/pandoc-convert.ts
+++ b/src/pandoc-convert.ts
@@ -279,6 +279,7 @@ export async function pandocConvert(
     pandocPath,
     latexEngine,
     imageMagickPath,
+    mermaidTheme,
   },
   config = {},
 ): Promise<string> {
@@ -420,6 +421,7 @@ export async function pandocConvert(
     codeChunksData,
     graphsCache,
     imageMagickPath,
+    mermaidTheme,
   });
 
   // pandoc will cause error if directory doesn't exist,

--- a/src/process-graphs.ts
+++ b/src/process-graphs.ts
@@ -346,34 +346,22 @@ export async function processGraphs(
       }
     } else if (def.match(/^ditaa/)) {
       try {
-        const pngFilePath = path.resolve(
-          imageDirectoryPath,
-          imageFilePrefix + imgCount + ".png",
+        const checksum = computeChecksum(optionsStr + content);
+        let svg = graphsCache[checksum];
+        if (!svg) {
+          // check whether in cache
+          svg = await ditaaAPI.render(content, options["args"]);
+        }
+        await convertSVGToPNGFile(
+          options["filename"],
+          svg,
+          lines,
+          start,
+          end,
+          true,
+          options["alt"],
+          optionsStr,
         );
-        imgCount++;
-        await ditaaAPI.render(content, options["args"], pngFilePath);
-
-        let displayPNGFilePath;
-        if (useRelativeFilePath) {
-          displayPNGFilePath =
-            path.relative(fileDirectoryPath, pngFilePath) + "?" + Math.random();
-        } else {
-          displayPNGFilePath =
-            "/" +
-            path.relative(projectDirectoryPath, pngFilePath) +
-            "?" +
-            Math.random();
-        }
-        clearCodeBlock(lines, start, end);
-
-        let altCaption = options["alt"];
-        if (altCaption == null) {
-          altCaption = "";
-        }
-        lines[end] +=
-          "\n" + `![${altCaption}](${displayPNGFilePath}){${optionsStr}}  `;
-
-        imagePaths.push(pngFilePath);
       } catch (error) {
         clearCodeBlock(lines, start, end);
         lines[end] += `\n` + `\`\`\`\n${error}\n\`\`\`  \n`;

--- a/src/process-graphs.ts
+++ b/src/process-graphs.ts
@@ -13,6 +13,7 @@ import * as vegaLiteAPI from "./vega-lite";
 import { Viz } from "./viz";
 import * as mermaidAPI from "./mermaid";
 import * as wavedromAPI from "./wavedrom";
+import * as ditaaAPI from "./ditaa";
 
 export async function processGraphs(
   text: string,
@@ -339,6 +340,40 @@ export async function processGraphs(
           options["alt"],
           optionsStr,
         );
+      } catch (error) {
+        clearCodeBlock(lines, start, end);
+        lines[end] += `\n` + `\`\`\`\n${error}\n\`\`\`  \n`;
+      }
+    } else if (def.match(/^ditaa/)) {
+      try {
+        const pngFilePath = path.resolve(
+          imageDirectoryPath,
+          imageFilePrefix + imgCount + ".png",
+        );
+        imgCount++;
+        await ditaaAPI.render(content, options["args"], pngFilePath);
+
+        let displayPNGFilePath;
+        if (useRelativeFilePath) {
+          displayPNGFilePath =
+            path.relative(fileDirectoryPath, pngFilePath) + "?" + Math.random();
+        } else {
+          displayPNGFilePath =
+            "/" +
+            path.relative(projectDirectoryPath, pngFilePath) +
+            "?" +
+            Math.random();
+        }
+        clearCodeBlock(lines, start, end);
+
+        let altCaption = options["alt"];
+        if (altCaption == null) {
+          altCaption = "";
+        }
+        lines[end] +=
+          "\n" + `![${altCaption}](${displayPNGFilePath}){${optionsStr}}  `;
+
+        imagePaths.push(pngFilePath);
       } catch (error) {
         clearCodeBlock(lines, start, end);
         lines[end] += `\n` + `\`\`\`\n${error}\n\`\`\`  \n`;

--- a/src/render-enhancers/fenced-diagrams.ts
+++ b/src/render-enhancers/fenced-diagrams.ts
@@ -1,11 +1,10 @@
 // tslint:disable:ban-types no-var-requires
-import { resolve } from "path";
 import * as YAML from "yamljs";
 
 import { render as renderDitaa } from "../ditaa";
 import computeChecksum from "../lib/compute-checksum";
 import { render as renderPlantuml } from "../puml";
-import { mkdirp, readFile, escapeString } from "../utility";
+import { escapeString } from "../utility";
 import { toSVG as vegaToSvg } from "../vega";
 import { toSVG as vegaLiteToSvg } from "../vega-lite";
 import { Viz } from "../viz";
@@ -203,18 +202,8 @@ async function renderDiagram(
 
         // ditaa diagram
         const args = normalizedInfo.attributes["args"] || [];
-        const filename =
-          normalizedInfo.attributes["filename"] ||
-          `${computeChecksum(`${JSON.stringify(args)} ${code}`)}.svg`;
-        await mkdirp(imageDirectoryPath);
 
-        const pathToSvg = await renderDitaa(
-          code,
-          args,
-          resolve(imageDirectoryPath, filename),
-        );
-        const pathToSvgWithoutVersion = pathToSvg.replace(/\?[\d\.]+$/, "");
-        const svg = await readFile(pathToSvgWithoutVersion);
+        const svg = await renderDitaa(code, args);
         $output = `<p ${stringifyAttributes(
           normalizedInfo.attributes,
         )}>${svg}</p>`;

--- a/src/wavedrom.ts
+++ b/src/wavedrom.ts
@@ -1,0 +1,33 @@
+/**
+ * A wrapper of wavedrom CLI
+ * https://github.com/wavedrom/cli
+ */
+
+import * as utility from "./utility";
+
+export async function render(
+  wavedromCode: string,
+  projectDirectoryPath: string,
+): Promise<string> {
+  const info = await utility.tempOpen({
+    prefix: "mume-wavedrom",
+    suffix: ".js",
+  });
+  await utility.write(info.fd, wavedromCode);
+  try {
+    const svg = await utility.execFile(
+      "npx",
+      ["wavedrom-cli", "-i", info.path],
+      {
+        shell: true,
+        cwd: projectDirectoryPath,
+      },
+    );
+    return svg;
+  } catch (error) {
+    throw new Error(
+      "wavedrom CLI is required to be installed.\nCheck http://github.com/wavedrom/cli for more information.\n\n" +
+        error.toString(),
+    );
+  }
+}


### PR DESCRIPTION
# Abstact

Add below diagrams

|Diagram|Limitation|Depend on|
|-|-|-|
|ditaa|||
|mermaid|PNG only|https://github.com/mermaid-js/mermaid.cli|
|wavedrom||https://github.com/wavedrom/cli|

support on

- GFM ( save as markdown)
- pandoc

export.

# Related issues

shd101wyy/markdown-preview-enhanced#1250
shd101wyy/markdown-preview-enhanced#952
shd101wyy/markdown-preview-enhanced#662
shd101wyy/markdown-preview-enhanced#609
shd101wyy/markdown-preview-enhanced#182
shd101wyy/markdown-preview-enhanced#138

shd101wyy/vscode-markdown-preview-enhanced#271
shd101wyy/vscode-markdown-preview-enhanced#261

# Note

## cli dependencies

npx required.
User should install package before export.
```bash
> yarn add @mermaid-js/mermaid.cli
> yarn add wavedrom-cli
```

## mermaid svg export

I tried latest ver (8.4.8) mermaid-cli.
Exported svg looks good on chrome.
But failed to convert svg to png by ImageMagick or Inkscape.
c.f.) https://github.com/mermaid-js/mermaid/issues/664

## flow, sequence

https://github.com/francoislaberge/diagrams did not worked.
Execfile(npx diagrams blabla...) throws error(code=1)
despite everything works well on terminal.

## Test

Tested ONLY on windows10.
Please check.