### PR TITLE
fix(puml.ts): fixed for plantuml output charset issue

### DIFF
--- a/src/puml.ts
+++ b/src/puml.ts
@@ -50,6 +50,7 @@ class PlantUMLTask {
   private startTask() {
     this.task = spawn("java", [
       "-Djava.awt.headless=true",
+      "-Dfile.encoding=UTF-8",
       "-Dplantuml.include.path=" +
         [this.fileDirectoryPath, extensionConfigDirectoryPath].join(
           path.delimiter,


### PR DESCRIPTION
This is encoding issue test case:
```plantuml
@startuml
digraph g {
    rankdir=LR;//方向左右
    用户->{发布机}[label=更新]
    }
@enduml
```