### PR TITLE
Add configPath to configure engine locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ const mume = require("@shd101wyy/mume");
 // import * as mume from "@shd101wyy/mume"
 
 async function main() {
-  await mume.init();
+  const configPath = path.resolve(os.homedir(), ".mume"); // use here your own config folder, default is "~/.mume"
+  await mume.init(configPath); // default uses "~/.mume"
 
   const engine = new mume.MarkdownEngine({
     filePath: "/Users/wangyiyi/Desktop/markdown-example/test3.md",
     config: {
+      configPath: configPath,
       previewTheme: "github-light.css",
       // revealjsTheme: "white.css"
       codeBlockTheme: "default.css",
@@ -65,6 +67,9 @@ main();
 
 ```js
 const config = {
+  // Default config directory, `null`  means "~./.mume"
+  configPath : null,
+  
   // Enable this option will render markdown by pandoc instead of markdown-it.
   usePandocParser: false,
 

--- a/src/markdown-engine-config.ts
+++ b/src/markdown-engine-config.ts
@@ -1,6 +1,7 @@
 export type MathRenderingOption = "None" | "KaTeX" | "MathJax";
 
 export interface MarkdownEngineConfig {
+  configPath?: string,
   usePandocParser?: boolean;
   breakOnSingleNewLine?: boolean;
   enableTypographer?: boolean;
@@ -41,6 +42,7 @@ export interface MarkdownEngineConfig {
 }
 
 export const defaultMarkdownEngineConfig: MarkdownEngineConfig = {
+  configPath: null,
   usePandocParser: false,
   breakOnSingleNewLine: true,
   enableTypographer: false,

--- a/src/markdown-engine.ts
+++ b/src/markdown-engine.ts
@@ -1043,7 +1043,7 @@ if (typeof(window['Reveal']) !== 'undefined') {
       this.config.usePandocParser
     ) {
       // TODO
-      const mathJaxConfig = await utility.getMathJaxConfig();
+      const mathJaxConfig = await utility.getMathJaxConfig(this.config.configPath);
       mathJaxConfig["tex2jax"]["inlineMath"] = this.config.mathInlineDelimiters;
       mathJaxConfig["tex2jax"]["displayMath"] = this.config.mathBlockDelimiters;
 
@@ -1103,7 +1103,7 @@ if (typeof(window['Reveal']) !== 'undefined') {
       } else {
         mermaidScript = `<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mermaid@8.5.0/dist/mermaid.min.js"></script>`;
       }
-      const mermaidConfig: string = await utility.getMermaidConfig();
+      const mermaidConfig: string = await utility.getMermaidConfig(this.config.configPath);
       mermaidInitScript += `<script>
 ${mermaidConfig}
 if (window['MERMAID_CONFIG']) {
@@ -1446,7 +1446,7 @@ for (var i = 0; i < flowcharts.length; i++) {
     // global styles
     let globalStyles = "";
     try {
-      globalStyles = await utility.getGlobalStyles();
+      globalStyles = await utility.getGlobalStyles(this.config.configPath);
     } catch (error) {
       // ignore it
     }
@@ -2129,7 +2129,7 @@ sidebarTOCBtn.addEventListener('click', function(event) {
     // global styles
     let globalStyles = "";
     try {
-      globalStyles = await utility.getGlobalStyles();
+      globalStyles = await utility.getGlobalStyles(this.config.configPath);
     } catch (error) {
       // ignore it
     }

--- a/src/mume.ts
+++ b/src/mume.ts
@@ -19,64 +19,64 @@ export { CodeChunkData } from "./code-chunk-data";
 /**
  * init mume config folder at ~/.mume
  */
-export async function init(): Promise<void> {
+export async function init(configPath: string | null): Promise<void> {
   if (INITIALIZED) {
     return;
   }
 
-  const homeDir = os.homedir();
-  const extensionConfigDirectoryPath = path.resolve(homeDir, "./.mume");
-  if (!fs.existsSync(extensionConfigDirectoryPath)) {
-    fs.mkdirSync(extensionConfigDirectoryPath);
+  configPath = configPath ? configPath : path.resolve(os.homedir(), "./.mume");
+
+  if (!fs.existsSync(configPath)) {
+    fs.mkdirSync(configPath);
   }
 
-  configs.globalStyle = await utility.getGlobalStyles();
-  configs.mermaidConfig = await utility.getMermaidConfig();
-  configs.mathjaxConfig = await utility.getMathJaxConfig();
-  configs.katexConfig = await utility.getKaTeXConfig();
-  configs.parserConfig = await utility.getParserConfig();
-  configs.config = await utility.getExtensionConfig();
+  configs.globalStyle = await utility.getGlobalStyles(configPath);
+  configs.mermaidConfig = await utility.getMermaidConfig(configPath);
+  configs.mathjaxConfig = await utility.getMathJaxConfig(configPath);
+  configs.katexConfig = await utility.getKaTeXConfig(configPath);
+  configs.parserConfig = await utility.getParserConfig(configPath);
+  configs.config = await utility.getExtensionConfig(configPath);
 
-  fs.watch(extensionConfigDirectoryPath, (eventType, fileName) => {
+  fs.watch(configPath, (eventType, fileName) => {
     if (eventType === "change") {
       if (fileName === "style.less") {
         // || fileName==='mermaid_config.js' || fileName==='mathjax_config')
-        utility.getGlobalStyles().then((css) => {
+        utility.getGlobalStyles(configPath).then((css) => {
           configs.globalStyle = css;
           if (CONFIG_CHANGE_CALLBACK) {
             CONFIG_CHANGE_CALLBACK();
           }
         });
       } else if (fileName === "mermaid_config.js") {
-        utility.getMermaidConfig().then((mermaidConfig) => {
+        utility.getMermaidConfig(configPath).then((mermaidConfig) => {
           configs.mermaidConfig = mermaidConfig;
           if (CONFIG_CHANGE_CALLBACK) {
             CONFIG_CHANGE_CALLBACK();
           }
         });
       } else if (fileName === "mathjax_config.js") {
-        utility.getMathJaxConfig().then((mathjaxConfig) => {
+        utility.getMathJaxConfig(configPath).then((mathjaxConfig) => {
           configs.mathjaxConfig = mathjaxConfig;
           if (CONFIG_CHANGE_CALLBACK) {
             CONFIG_CHANGE_CALLBACK();
           }
         });
       } else if (fileName === "katex_config.js") {
-        utility.getKaTeXConfig().then((katexConfig) => {
+        utility.getKaTeXConfig(configPath).then((katexConfig) => {
           configs.katexConfig = katexConfig;
           if (CONFIG_CHANGE_CALLBACK) {
             CONFIG_CHANGE_CALLBACK();
           }
         });
       } else if (fileName === "parser.js") {
-        utility.getParserConfig().then((parserConfig) => {
+        utility.getParserConfig(configPath).then((parserConfig) => {
           configs.parserConfig = parserConfig;
           if (CONFIG_CHANGE_CALLBACK) {
             CONFIG_CHANGE_CALLBACK();
           }
         });
       } else if (fileName === "config.json") {
-        utility.getExtensionConfig().then((config) => {
+        utility.getExtensionConfig(configPath).then((config) => {
           configs.config = config;
           if (CONFIG_CHANGE_CALLBACK) {
             CONFIG_CHANGE_CALLBACK();

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -192,9 +192,10 @@ export const extensionDirectoryPath = path.resolve(__dirname, "../../");
 /**
  * compile ~/.mumi/style.less and return 'css' content.
  */
-export async function getGlobalStyles(): Promise<string> {
-  const homeDir = os.homedir();
-  const globalLessFilePath = path.resolve(homeDir, "./.mume/style.less");
+export async function getGlobalStyles(configPath): Promise<string> {
+  const globalLessFilePath = configPath
+    ? path.resolve(configPath, "./styles.less")
+    : path.resolve(os.homedir(), "./.mume/styles.less");
 
   let fileContent: string;
   try {
@@ -235,9 +236,10 @@ export async function getGlobalStyles(): Promise<string> {
 /**
  * load ~/.mume/mermaid_config.js file.
  */
-export async function getMermaidConfig(): Promise<string> {
-  const homeDir = os.homedir();
-  const mermaidConfigPath = path.resolve(homeDir, "./.mume/mermaid_config.js");
+export async function getMermaidConfig(configPath): Promise<string> {
+  const mermaidConfigPath = configPath
+    ? path.resolve(configPath, "./mermaid_config.js")
+    : path.resolve(os.homedir(), "./.mume/mermaid_config.js");
 
   let mermaidConfig: string;
   if (fs.existsSync(mermaidConfigPath)) {
@@ -288,9 +290,10 @@ export const defaultKaTeXConfig = {
 /**
  * load ~/.mume/mathjax_config.js file.
  */
-export async function getMathJaxConfig(): Promise<object> {
-  const homeDir = os.homedir();
-  const mathjaxConfigPath = path.resolve(homeDir, "./.mume/mathjax_config.js");
+export async function getMathJaxConfig(configPath): Promise<object> {
+  const mathjaxConfigPath = configPath
+    ? path.resolve(configPath, "./mathjax_config.js")
+    : path.resolve(os.homedir(), "./.mume/mathjax_config.js");
 
   let mathjaxConfig: object;
   if (fs.existsSync(mathjaxConfigPath)) {
@@ -326,9 +329,10 @@ module.exports = {
 /**
  * load ~/.mume/katex_config.js file
  */
-export async function getKaTeXConfig(): Promise<object> {
-  const homeDir = os.homedir();
-  const katexConfigPath = path.resolve(homeDir, "./.mume/katex_config.js");
+export async function getKaTeXConfig(configPath): Promise<object> {
+  const katexConfigPath = configPath
+    ? path.resolve(configPath, "./katex_config.js")
+    : path.resolve(os.homedir(), "./.mume/katex_config.js");
 
   let katexConfig: object;
   if (fs.existsSync(katexConfigPath)) {
@@ -349,9 +353,10 @@ module.exports = {
   return katexConfig;
 }
 
-export async function getExtensionConfig(): Promise<object> {
-  const homeDir = os.homedir();
-  const extensionConfigFilePath = path.resolve(homeDir, "./.mume/config.json");
+export async function getExtensionConfig(configPath): Promise<object> {
+  const extensionConfigFilePath = configPath
+    ? path.resolve(configPath, "./config.json")
+    : path.resolve(os.homedir(), "./.mume/config.json");
 
   let config: object;
   if (fs.existsSync(extensionConfigFilePath)) {
@@ -368,28 +373,10 @@ export async function getExtensionConfig(): Promise<object> {
   return config;
 }
 
-/**
- * Update ~/.mume/config.json
- * @param newConfig The new config.
- */
-export async function updateExtensionConfig(newConfig = {}): Promise<void> {
-  let config = await getExtensionConfig();
-  config = Object.assign(config, newConfig);
-
-  const homeDir = os.homedir();
-  fs.writeFile(
-    path.resolve(homeDir, "./.mume/config.json"),
-    JSON.stringify(config, null, 2),
-    { encoding: "utf-8" },
-    () => {
-      return;
-    },
-  );
-}
-
-export async function getParserConfig(): Promise<object> {
-  const homeDir = os.homedir();
-  const parserConfigPath = path.resolve(homeDir, "./.mume/parser.js");
+export async function getParserConfig(configPath): Promise<object> {
+  const parserConfigPath = configPath
+    ? path.resolve(configPath, "./parser.js")
+    : path.resolve(os.homedir(), "./.mume/parser.js");
 
   let parserConfig: object;
   if (fs.existsSync(parserConfigPath)) {


### PR DESCRIPTION
I think these changes allow to use the engine, with a custom config path `confiPath`.
If `null` then `os.homedir()/.mume` is used.
It should not change anything else externally, so VS Code extension still works.

Another **not** yet included improvment would be **IF** we could set this `configPath` inside VS Code (workspace/user) and that the engine restarts (maybe when the preview get opened...?) with the correct config path
This is helpful to have these settings individual for a repository set in the `.vscode/settings.json` or globally.  