### PR TITLE
Interpolate configPath

### DIFF
--- a/src/markdown-engine.ts
+++ b/src/markdown-engine.ts
@@ -292,6 +292,8 @@ export class MarkdownEngine {
    * Set default values
    */
   private initConfig() {
+    this.interpolateConfig(this.config, this.projectDirectoryPath);
+
     // break on single newline
     this.breakOnSingleNewLine = this.config.breakOnSingleNewLine;
 
@@ -311,6 +313,28 @@ export class MarkdownEngine {
     this.protocolsWhiteListRegExp = new RegExp(
       "^(" + protocolsWhiteList.join("|") + ")",
     ); // eg /^(http:\/\/|https:\/\/|atom:\/\/|file:\/\/|mailto:|tel:)/
+  }
+
+  public interpolateConfig(
+    config: MarkdownEngineConfig,
+    projectDirectoryPath: string,
+  ) {
+    const pattern = /\${\s*(\w+?)\s*}/g; // Replace ${property}
+
+    const replacements = {
+      projectDir: projectDirectoryPath,
+      workspaceFolder: projectDirectoryPath, // vscode abreviation
+    };
+
+    // Replace certains pathss
+    [
+      config.configPath,
+      config.imageFolderPath,
+      config.imageMagickPath,
+      config.chromePath,
+    ].forEach((x) => {
+      x.replace(pattern, (match, token) => replacements[token] || match);
+    });
   }
 
   public updateConfiguration(config) {


### PR DESCRIPTION
It would be good to interpolate the 
`configPath` variable

- `${projectDir}` is replaced with the values of the `this.projectDirPath` of the engine.

Thanks for merging.

PS: in VsCode we can now configure the configPath `${projectDir}/settings` for example and the settings are set into this folder.