### PR TITLE
Add callback to transformMarkdown

### DIFF
--- a/src/markdown-convert.ts
+++ b/src/markdown-convert.ts
@@ -188,6 +188,8 @@ export async function markdownConvert(
     usePandocParser,
     imageMagickPath,
     mermaidTheme,
+    onWillTransformMarkdown = null,
+    onDidTransformMarkdown = null,
   }: {
     projectDirectoryPath: string;
     fileDirectoryPath: string;
@@ -202,6 +204,8 @@ export async function markdownConvert(
     usePandocParser: boolean;
     imageMagickPath: string;
     mermaidTheme: string;
+    onWillTransformMarkdown?: any;
+    onDidTransformMarkdown?: any;
   },
   config: object,
 ): Promise<string> {
@@ -239,6 +243,10 @@ export async function markdownConvert(
 
   const useRelativeFilePath = !config["absolute_image_path"];
 
+  if (onWillTransformMarkdown) {
+    text = await onWillTransformMarkdown(text);
+  }
+
   // import external files
   const data = await transformMarkdown(text, {
     fileDirectoryPath,
@@ -250,8 +258,15 @@ export async function markdownConvert(
     protocolsWhiteListRegExp,
     imageDirectoryPath,
     usePandocParser,
+    onWillTransformMarkdown,
+    onDidTransformMarkdown,
   });
+
   text = data.outputString;
+
+  if (onDidTransformMarkdown) {
+    text = await onDidTransformMarkdown(text);
+  }
 
   // replace [MUMETOC]
   const tocBracketEnabled = data.tocBracketEnabled;

--- a/src/markdown-engine.ts
+++ b/src/markdown-engine.ts
@@ -2258,6 +2258,10 @@ sidebarTOCBtn.addEventListener('click', function(event) {
         latexEngine: this.config.latexEngine,
         imageMagickPath: this.config.imageMagickPath,
         mermaidTheme: this.config.mermaidTheme,
+        onWillTransformMarkdown:
+          utility.configs.parserConfig["onWillTransformMarkdown"],
+        onDidTransformMarkdown:
+          utility.configs.parserConfig["onDidTransformMarkdown"],
       },
       config,
     );
@@ -2361,6 +2365,10 @@ sidebarTOCBtn.addEventListener('click', function(event) {
         usePandocParser: this.config.usePandocParser,
         imageMagickPath: this.config.imageMagickPath,
         mermaidTheme: this.config.mermaidTheme,
+        onWillTransformMarkdown:
+          utility.configs.parserConfig["onWillTransformMarkdown"],
+        onDidTransformMarkdown:
+          utility.configs.parserConfig["onDidTransformMarkdown"],
       },
       markdownConfig,
     );
@@ -2771,6 +2779,12 @@ sidebarTOCBtn.addEventListener('click', function(event) {
       );
     }
 
+    if (utility.configs.parserConfig["onWillTransformMarkdown"]) {
+      inputString = await utility.configs.parserConfig[
+        "onWillTransformMarkdown"
+      ](inputString);
+    }
+
     // import external files and insert anchors if necessary
     let outputString;
     let slideConfigs;
@@ -2793,7 +2807,17 @@ sidebarTOCBtn.addEventListener('click', function(event) {
       useRelativeFilePath: options.useRelativeFilePath,
       filesCache: this.filesCache,
       usePandocParser: this.config.usePandocParser,
+      onWillTransformMarkdown:
+        utility.configs.parserConfig["onWillTransformMarkdown"],
+      onDidTransformMarkdown:
+        utility.configs.parserConfig["onDidTransformMarkdown"],
     }));
+
+    if (utility.configs.parserConfig["onDidTransformMarkdown"]) {
+      outputString = await utility.configs.parserConfig[
+        "onDidTransformMarkdown"
+      ](outputString);
+    }
 
     // process front-matter
     const fm = this.processFrontMatter(

--- a/src/pandoc-convert.ts
+++ b/src/pandoc-convert.ts
@@ -281,6 +281,8 @@ export async function pandocConvert(
     latexEngine,
     imageMagickPath,
     mermaidTheme,
+    onWillTransformMarkdown = null,
+    onDidTransformMarkdown = null,
   },
   config = {},
 ): Promise<string> {
@@ -366,6 +368,10 @@ export async function pandocConvert(
   // process output config
   processOutputConfig(outputConfig || {}, args, latexEngine);
 
+  if (onWillTransformMarkdown) {
+    text = await onWillTransformMarkdown(text);
+  }
+
   // import external files
   const data = await transformMarkdown(text, {
     fileDirectoryPath,
@@ -375,8 +381,14 @@ export async function pandocConvert(
     protocolsWhiteListRegExp,
     forPreview: false,
     usePandocParser: true,
+    onWillTransformMarkdown,
+    onDidTransformMarkdown,
   });
   text = data.outputString;
+
+  if (onDidTransformMarkdown) {
+    text = await onDidTransformMarkdown(text);
+  }
 
   // add front-matter(yaml) back to text
   text = "---\n" + YAML.stringify(config) + "---\n" + text;

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -62,6 +62,8 @@ export interface TransformMarkdownOptions {
   imageDirectoryPath?: string;
   usePandocParser: boolean;
   headingIdGenerator?: HeadingIdGenerator;
+  onWillTransformMarkdown?: (markdown: string) => string;
+  onDidTransformMarkdown?: (markdown: string) => string;
 }
 
 const fileExtensionToLanguageMap = {
@@ -253,6 +255,8 @@ export async function transformMarkdown(
     imageDirectoryPath = "",
     usePandocParser = false,
     headingIdGenerator = new HeadingIdGenerator(),
+    onWillTransformMarkdown = null,
+    onDidTransformMarkdown = null,
   }: TransformMarkdownOptions,
 ): Promise<TransformMarkdownOutput> {
   let lastOpeningCodeBlockFence: string = null;
@@ -788,6 +792,9 @@ export async function transformMarkdown(
                 config,
               )}  \n${fileContent}\n\`\`\`  `;
             } else if ([".md", ".markdown", ".mmark"].indexOf(extname) >= 0) {
+              if (onWillTransformMarkdown) {
+                fileContent = await onWillTransformMarkdown(fileContent);
+              }
               // markdown files
               // this return here is necessary
               let output2;
@@ -808,6 +815,11 @@ export async function transformMarkdown(
                 usePandocParser,
                 headingIdGenerator,
               }));
+
+              if (onDidTransformMarkdown) {
+                output2 = await onDidTransformMarkdown(output2);
+              }
+
               output2 = "\n" + output2 + "  ";
               headings = headings.concat(headings2);
 

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -376,6 +376,16 @@ export async function getParserConfig(configPath): Promise<object> {
     return new Promise((resolve, reject)=> {
       return resolve(html)
     })
+  },
+  onWillTransformMarkdown: function (markdown) {
+        return new Promise((resolve, reject) => {
+            return resolve(markdown);
+        });
+    },
+  onDidTransformMarkdown: function (markdown) {
+      return new Promise((resolve, reject) => {
+          return resolve(markdown);
+      });
   }
 }`;
     await writeFile(parserConfigPath, template, { encoding: "utf-8" });


### PR DESCRIPTION
This adds two additional parser call backs which are called before and after `transformMarkdown`
This is needed to adjust the parsed markdown for certain other things...:

```javscript
 onWillTransformMarkdown: function (markdown) {
        return new Promise((resolve, reject) => {
            return resolve(markdown);
        });
    },
  onDidTransformMarkdown: function (markdown) {
        return new Promise((resolve, reject) => {
            return resolve(markdown);
        });
    }
```
Thanks for merging.
