### PR TITLE
Bugfix: pandoc_args need to override completely at the end not before

### DIFF
--- a/src/pandoc-convert.ts
+++ b/src/pandoc-convert.ts
@@ -62,10 +62,6 @@ function processOutputConfig(
     args.push("--no-highlight");
   }
 
-  if (config["pandoc_args"]) {
-    config["pandoc_args"].forEach((arg) => args.push(arg));
-  }
-
   if (config["citation_package"]) {
     if (config["citation_package"] === "natbib") {
       args.push("--natbib");
@@ -132,6 +128,12 @@ function processOutputConfig(
 
   if (config["template"]) {
     args.push("--template=" + config["template"]);
+  }
+  
+  // All other arguments give here can override the 
+  // defaults from above
+  if (config["pandoc_args"]) {
+    config["pandoc_args"].forEach((arg) => args.push(arg));
   }
 }
 


### PR DESCRIPTION
Why: in this way we can properly use additional defaults which **get combined** 
`--defaults=my-default.yaml` See https://pandoc.org/MANUAL.html#default-files

If we have set a pdf-engine in the defaults pandoc file, it gets overwritten by the code right now which is unfortunate and conversion will fail.