### PR TITLE
Agnostically add citeproc filter

### DIFF
--- a/src/markdown-engine.ts
+++ b/src/markdown-engine.ts
@@ -2845,7 +2845,15 @@ sidebarTOCBtn.addEventListener('click', function(event) {
         }
 
         // check bibliography
-        if (yamlConfig["bibliography"] || yamlConfig["references"]) {
+        const noDefaultsOrCiteProc =
+          args.find((el) => {
+            return el.includes("pandoc-citeproc") || el.includes("--defaults");
+          }) === undefined;
+
+        if (
+          noDefaultsOrCiteProc &&
+          (yamlConfig["bibliography"] || yamlConfig["references"])
+        ) {
           args.push("--filter", "pandoc-citeproc");
         }
 

--- a/src/pandoc-convert.ts
+++ b/src/pandoc-convert.ts
@@ -129,8 +129,8 @@ function processOutputConfig(
   if (config["template"]) {
     args.push("--template=" + config["template"]);
   }
-  
-  // All other arguments give here can override the 
+
+  // All other arguments give here can override the
   // defaults from above
   if (config["pandoc_args"]) {
     config["pandoc_args"].forEach((arg) => args.push(arg));
@@ -413,7 +413,15 @@ export async function pandocConvert(
   text = processPaths(text, fileDirectoryPath, projectDirectoryPath);
 
   // citation
-  if (config["bibliography"] || config["references"]) {
+  const noDefaultsOrCiteProc =
+    args.find((el) => {
+      return el.includes("pandoc-citeproc") || el.includes("--defaults");
+    }) === undefined;
+
+  if (
+    noDefaultsOrCiteProc &&
+    (config["bibliography"] || config["references"])
+  ) {
     args.push("--filter", "pandoc-citeproc");
   }
 


### PR DESCRIPTION
Thx for merging.

Without checking these arguments, `--filter pandoc-citeproc` is added twice resulting in a double bibliography....