### PR TITLE
fix: Fix equation numbering on MathJax re-render

### DIFF
--- a/src/webview.ts
+++ b/src/webview.ts
@@ -866,6 +866,7 @@
           }
 
           window["MathJax"].Hub.Queue(
+            ["resetEquationNumbers", MathJax.InputJax.TeX],
             ["Typeset", MathJax.Hub, this.hiddenPreviewElement],
             [
               () => {


### PR DESCRIPTION
References:
- https://docs.mathjax.org/en/v2.7-latest/advanced/typeset.html#reset-equation-numbers
- https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/67

This seems to _partially_ fix https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/67, https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/1305, and a bunch of other similar issues. 

**However,** this solution is not yet complete:
- There could be some performance impact?
- The **first render** right after opening preview still produces wrong numbering and bad labels, and I have no idea why... Fortunately, a change in any formula will promptly restore the correct numbering and labels. 
