### PR TITLE
Fix: Rendering of utf8 encoding source

### DIFF
--- a/src/puml-server.ts
+++ b/src/puml-server.ts
@@ -10,6 +10,7 @@ export default class PlantUMLServerTask {
 
   public generateSVG(content: string): Promise<string> {
     const contentStream = new Readable();
+    contentStream.setEncoding("utf-8");
     contentStream.push(content);
     contentStream.push(null); // Mark end of stream
     return fetch(this.serverURL, {


### PR DESCRIPTION
Fix:Rendering of utf8 encoding source
for example:

```puml
@startuml

title 样例
源 -> 目标 :测试
@enduml
```