### PR TITLE
Fixes compatibility with current plantuml

### DIFF
--- a/src/puml.ts
+++ b/src/puml.ts
@@ -72,11 +72,11 @@ class PlantUMLTask {
         data = this.chunks;
         this.chunks = ""; // clear CHUNKS
         const diagrams = data.split("<?xml ");
-        diagrams.forEach((diagram, i) => {
+        diagrams.forEach((diagram) => {
           if (diagram.length) {
             const callback = this.callbacks.shift();
             if (callback) {
-              callback("<?xml " + diagram);
+              callback(diagram);
             }
           }
         });


### PR DESCRIPTION
Fixes #232 . For some reason, it is no longer required (or possible) to prefix the output of plantuml with "<?xml ", which was required last time I tried.