### PR TITLE
Default to `XDG_CONFIG_HOME/mume` instead of `~/.mume` for `configPath`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,11 @@ const mume = require("@shd101wyy/mume");
 // import * as mume from "@shd101wyy/mume"
 
 async function main() {
-  const configPath = path.resolve(os.homedir(), ".mume"); // use here your own config folder, default is "~/.mume"
-  await mume.init(configPath); // default uses "~/.mume"
+  const configPath = path.resolve(os.tmpdir(), ".mume");
+
+  // if no configPath is specified, the default is "~/.config/mume"
+  // but only if the old location (~/.mume) does not exist
+  await mume.init(configPath);
 
   const engine = new mume.MarkdownEngine({
     filePath: "/Users/wangyiyi/Desktop/markdown-example/test3.md",
@@ -73,7 +76,7 @@ main();
 
 ```js
 const config = {
-  // Default config directory, `null`  means "~./.mume"
+  // Default config directory; `null` means "~/.config/mume"
   configPath : null,
 
   // Enable this option will render markdown by pandoc instead of markdown-it.
@@ -254,7 +257,7 @@ const engine = new mume.MarkdownEngine({
 
 ## Global Configuration
 
-Global config files are located at `~/.mume` directory
+Global config files are located in the `$XDG_STATE_HOME/mume` directory, which is `~/.config/mume` by default
 
 ## Development
 

--- a/src/markdown-engine.ts
+++ b/src/markdown-engine.ts
@@ -274,7 +274,7 @@ export class MarkdownEngine {
    * Reset config
    */
   public resetConfig() {
-    // Please notice that ~/.mume/config.json has the highest priority.
+    // Please notice that ~/.config/mume/config.json has the highest priority.
     this.config = {
       ...defaultMarkdownEngineConfig,
       ...(this.originalConfig || {}),

--- a/src/mume.ts
+++ b/src/mume.ts
@@ -2,7 +2,6 @@
  * The core of mume package.
  */
 import * as fs from "fs";
-import * as os from "os";
 import * as path from "path";
 import * as mkdirp from "mkdirp";
 

--- a/src/mume.ts
+++ b/src/mume.ts
@@ -16,19 +16,17 @@ export { MarkdownEngineConfig } from "./markdown-engine-config";
 export { MarkdownEngine } from "./markdown-engine";
 export { CodeChunkData } from "./code-chunk-data";
 
-let extensionConfigPath = path.resolve(os.homedir(), "./.mume");
+let extensionConfigPath = utility.getConfigPath();
 
 /**
- * init mume config folder at ~/.mume
+ * init mume config folder at ~/.config/mume
  */
 export async function init(configPath: string | null = null): Promise<void> {
   if (INITIALIZED) {
     return;
   }
 
-  configPath = configPath
-    ? path.resolve(configPath)
-    : path.resolve(os.homedir(), "./.mume");
+  configPath = configPath ? path.resolve(configPath) : utility.getConfigPath();
   extensionConfigPath = configPath;
 
   if (!fs.existsSync(configPath)) {

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -184,7 +184,7 @@ export const extensionDirectoryPath = path.resolve(__dirname, "../../");
 export async function getGlobalStyles(configPath): Promise<string> {
   const globalLessFilePath = configPath
     ? path.resolve(configPath, "./style.less")
-    : path.resolve(os.homedir(), "./.mume/style.less");
+    : path.resolve(getConfigPath(), "./style.less");
 
   let fileContent: string;
   try {
@@ -223,12 +223,35 @@ export async function getGlobalStyles(configPath): Promise<string> {
 }
 
 /**
- * load ~/.mume/mermaid_config.js file.
+ * Get default config path
+ * @
+ */
+export function getConfigPath() {
+  const oldDefault = path.resolve(os.homedir(), "./.mume");
+
+  // For compatibility, use the old directory if it exists
+  if (fs.existsSync(oldDefault)) {
+    return oldDefault;
+  } else {
+    // Calculate new default
+    if (
+      typeof process.env.XDG_CONFIG_HOME === "string" &&
+      process.env.XDG_CONFIG_HOME !== ""
+    ) {
+      return path.resolve(process.env.XDG_CONFIG_HOME, "./mume");
+    } else {
+      return path.resolve(os.homedir(), "./.local/state/mume");
+    }
+  }
+}
+
+/**
+ * load ~/.config/mume/mermaid_config.js file.
  */
 export async function getMermaidConfig(configPath): Promise<string> {
   const mermaidConfigPath = configPath
     ? path.resolve(configPath, "./mermaid_config.js")
-    : path.resolve(os.homedir(), "./.mume/mermaid_config.js");
+    : path.resolve(getConfigPath(), "./mermaid_config.js");
 
   let mermaidConfig: string;
   if (fs.existsSync(mermaidConfigPath)) {
@@ -277,12 +300,12 @@ export const defaultKaTeXConfig = {
 };
 
 /**
- * load ~/.mume/mathjax_config.js file.
+ * load ~/.config/mume/mathjax_config.js file.
  */
 export async function getMathJaxConfig(configPath): Promise<object> {
   const mathjaxConfigPath = configPath
     ? path.resolve(configPath, "./mathjax_config.js")
-    : path.resolve(os.homedir(), "./.mume/mathjax_config.js");
+    : path.resolve(getConfigPath(), "./mathjax_config.js");
 
   let mathjaxConfig: object;
   if (fs.existsSync(mathjaxConfigPath)) {
@@ -316,12 +339,12 @@ module.exports = {
 }
 
 /**
- * load ~/.mume/katex_config.js file
+ * load ~/.config/mume/katex_config.js file
  */
 export async function getKaTeXConfig(configPath): Promise<object> {
   const katexConfigPath = configPath
     ? path.resolve(configPath, "./katex_config.js")
-    : path.resolve(os.homedir(), "./.mume/katex_config.js");
+    : path.resolve(getConfigPath(), "./katex_config.js");
 
   let katexConfig: object;
   if (fs.existsSync(katexConfigPath)) {
@@ -345,7 +368,7 @@ module.exports = {
 export async function getExtensionConfig(configPath): Promise<object> {
   const extensionConfigFilePath = configPath
     ? path.resolve(configPath, "./config.json")
-    : path.resolve(os.homedir(), "./.mume/config.json");
+    : path.resolve(getConfigPath(), "./config.json");
 
   let config: object;
   if (fs.existsSync(extensionConfigFilePath)) {
@@ -365,7 +388,7 @@ export async function getExtensionConfig(configPath): Promise<object> {
 export async function getParserConfig(configPath): Promise<ParserConfig> {
   const parserConfigPath = configPath
     ? path.resolve(configPath, "./parser.js")
-    : path.resolve(os.homedir(), "./.mume/parser.js");
+    : path.resolve(getConfigPath(), "./parser.js");
 
   let parserConfig: ParserConfig;
   if (fs.existsSync(parserConfigPath)) {

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -229,8 +229,9 @@ export async function getGlobalStyles(configPath): Promise<string> {
 export function getConfigPath() {
   const oldDefault = path.resolve(os.homedir(), "./.mume");
 
-  // For compatibility, use the old directory if it exists
-  if (fs.existsSync(oldDefault)) {
+  // For compatibility, use the old directory if either it exists
+  // or the user is on windows
+  if (fs.existsSync(oldDefault) || process.platform === "win32") {
     return oldDefault;
   } else {
     // Calculate new default


### PR DESCRIPTION
PR #173 made it possible to easily change the `configPath` for mume. This changes the default to `~/.config/mume` instead of `~/.mume` (but only if `~/.mume` does not exist!) to remove clutter in the home directory.

This would close #66