### PR TITLE
Fix parsing interactive mode vega specs when <= is present

### DIFF
--- a/src/render-enhancers/fenced-diagrams.ts
+++ b/src/render-enhancers/fenced-diagrams.ts
@@ -177,7 +177,7 @@ async function renderDiagram(
             spec = JSON.parse(rawSpec);
           }
           $output = hiddenCode(
-            JSON.stringify(spec),
+            JSON.stringify(spec).replace("<", "&lt;"),
             normalizedInfo.attributes,
             normalizedInfo.language,
           );


### PR DESCRIPTION
This PR is a cherry-picked version of https://github.com/gicentre/mume-with-litvis/commit/ef534a18a2e1d90e4eccdcd07166f42b79d91896

Issue details: https://github.com/gicentre/litvis/issues/22

Spotted via: https://github.com/gicentre/mume-with-litvis/pull/12