### PR TITLE
Render plantuml errors in doc

### DIFF
--- a/src/puml.ts
+++ b/src/puml.ts
@@ -83,7 +83,11 @@ class PlantUMLTask {
       }
     });
 
-    this.task.on("error", () => this.closeSelf());
+    this.task.on("error", (err) => {
+      // Return error object to rendered doc
+      this.callbacks.forEach((cb) => cb(JSON.stringify(err)));
+      this.closeSelf();
+    });
     this.task.on("exit", () => this.closeSelf());
   }
 


### PR DESCRIPTION
Currently, spawned plantuml process hangs up if there is a problem with java installation, plantuml binary or args. This PR makes those errors available in the rendered doc for easier debugging.