### PR TITLE
doc: update example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ npm install --save @shd101wyy/mume
 
 ```javascript
 // node.js
+const path = require("path");
 const mume = require("@shd101wyy/mume");
 
 // es6


### PR DESCRIPTION
The example code provided in the `README` file was not executable after only changing the configurations, since the import statement for the `path` module was missing.

This PR fixes this issue.