### PR TITLE
add graphviz in addition to viz and dot

### DIFF
--- a/src/extension-helper.ts
+++ b/src/extension-helper.ts
@@ -44,6 +44,7 @@ const scopesForLanguageName = {
   "plantuml": "plantuml",
   "puml": "plantuml",
   "wavedrom": "wavedrom",
+  "graphviz": "dot",
   "viz": "dot",
   "dot": "dot",
   "erd": "erd",

--- a/src/render-enhancers/fenced-diagrams.ts
+++ b/src/render-enhancers/fenced-diagrams.ts
@@ -39,6 +39,7 @@ const supportedLanguages = [
   "seq",
   "sequence-diagram",
   "wavedrom",
+  "graphviz",
   "viz",
   "dot",
   "vega",
@@ -157,6 +158,7 @@ async function renderDiagram(
         )}>${svg}</p>`;
         break;
       }
+      case "graphviz":
       case "viz":
       case "dot": {
         let svg = diagramInCache;

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -896,7 +896,8 @@ export async function transformMarkdown(
             } else if (
               extname === ".dot" ||
               extname === ".gv" ||
-              extname === ".viz"
+              extname === ".viz" ||
+              extname === ".graphviz"
             ) {
               // graphviz
               output = `\`\`\`dot ${stringifyBlockAttributes(


### PR DESCRIPTION
Simple change to add support to `graphviz` in markdown (alongside `viz` and `dot` as in

```markdown
```graphviz
digraph finite_state_machine {
    rankdir=LR;
    size="8,5"

    node [shape = doublecircle]; S;
    node [shape = point ]; qi

    node [shape = circle];
    qi -> S;
    S  -> q1 [ label = "a" ];
    S  -> S  [ label = "a" ];
    q1 -> S  [ label = "a" ];
    q1 -> q2 [ label = "ddb" ];
    q2 -> q1 [ label = "b" ];
    q2 -> q2 [ label = "b" ];
}
```

Many downstream tools, like mkdocs or kroki, use `graphviz` and neither `viz` nor `dot` 

Successfully tested in the VSCode extension