### PR TITLE
build(deps): bump twemoji to v13.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "request": "^2.88.0",
     "slash": "^2.0.0",
     "temp": "^0.9.0",
-    "twemoji": "^12.1.5",
+    "twemoji": "^13.1.0",
     "uslug": "^1.0.4",
     "vega-loader": "^4.1.0",
     "yamljs": "^0.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4098,19 +4098,19 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.npm.taobao.org/tweetnacl/download/tweetnacl-0.14.5.tgz?cache=0&sync_timestamp=1581365004105&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Ftweetnacl%2Fdownload%2Ftweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
-twemoji-parser@12.1.3:
-  version "12.1.3"
-  resolved "https://registry.npm.taobao.org/twemoji-parser/download/twemoji-parser-12.1.3.tgz#916c0153e77bd5f1011e7a99cbeacf52e43c9371"
-  integrity sha1-kWwBU+d71fEBHnqZy+rPUuQ8k3E=
+twemoji-parser@13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/twemoji-parser/-/twemoji-parser-13.1.0.tgz#65e7e449c59258791b22ac0b37077349127e3ea4"
+  integrity sha512-AQOzLJpYlpWMy8n+0ATyKKZzWlZBJN+G0C+5lhX7Ftc2PeEVdUU/7ns2Pn2vVje26AIZ/OHwFoUbdv6YYD/wGg==
 
-twemoji@^12.1.5:
-  version "12.1.6"
-  resolved "https://registry.npm.taobao.org/twemoji/download/twemoji-12.1.6.tgz#3425427627a38ab5cae24e7690cecb691022479f"
-  integrity sha1-NCVCdiejirXK4k52kM7LaRAiR58=
+twemoji@^13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/twemoji/-/twemoji-13.1.0.tgz#65bb71e966dae56f0d42c30176f04cbdae109913"
+  integrity sha512-e3fZRl2S9UQQdBFLYXtTBT6o4vidJMnpWUAhJA+yLGR+kaUTZAt3PixC0cGvvxWSuq2MSz/o0rJraOXrWw/4Ew==
   dependencies:
     fs-extra "^8.0.1"
     jsonfile "^5.0.0"
-    twemoji-parser "12.1.3"
+    twemoji-parser "13.1.0"
     universalify "^0.1.2"
 
 type-check@~0.3.2:


### PR DESCRIPTION
Hey! :wave:

This PR update [twemoji](https://www.npmjs.com/package/twemoji) to support [Unicode 13.0 spec](https://unicode.org/versions/Unicode13.0.0/) emojis.