### PR TITLE
Bump cheerio to fix vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "babyparse": "^0.4.6",
-    "cheerio": "1.0.0-rc.3",
+    "cheerio": "^1.0.0-rc.11",
     "chrome-location": "^1.2.1",
     "fs-extra": "^8.0.1",
     "imagemagick-cli": "^0.5.0",
@@ -62,7 +62,6 @@
     "yamljs": "^0.3.0"
   },
   "devDependencies": {
-    "@types/cheerio": "0.22.11",
     "@types/jest": "^27.0.2",
     "@types/jquery": "^3.3.29",
     "@types/markdown-it": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,6 @@
     "ts-jest": "^27.0.5",
     "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "^4.4.3"
+    "typescript": "^4.7.4"
   }
 }

--- a/src/markdown-engine.ts
+++ b/src/markdown-engine.ts
@@ -1539,7 +1539,7 @@ sidebarTOCBtn.addEventListener('click', function(event) {
     if (html.indexOf("task-list-item-checkbox") >= 0) {
       const $ = cheerio.load("<div>" + html + "</div>");
       $(".task-list-item-checkbox").each(
-        (index: number, elem: CheerioElement) => {
+        (index: number, elem: cheerio.Element) => {
           const $elem = $(elem);
           let $li = $elem.parent();
           if (!$li[0].name.match(/^li$/i)) {

--- a/src/render-enhancers/code-block-styling.ts
+++ b/src/render-enhancers/code-block-styling.ts
@@ -1,10 +1,11 @@
+import { Cheerio, CheerioAPI, Element } from "cheerio";
 import { resolve } from "path";
 import { scopeForLanguageName } from "../extension-helper";
 import { BlockInfo } from "../lib/block-info";
 import { escapeString, extensionDirectoryPath } from "../utility";
 let Prism;
 
-export default async function enhance($: CheerioStatic): Promise<void> {
+export default async function enhance($: CheerioAPI): Promise<void> {
   // spaced code blocks
   // this is for pandoc parser
   $("pre>code").each((i, codeElement) => {
@@ -33,7 +34,7 @@ export default async function enhance($: CheerioStatic): Promise<void> {
     const code = $container.text();
 
     // determine code language
-    const info: BlockInfo = $container.data("normalizedInfo");
+    const info = $container.data("normalizedInfo") as BlockInfo;
     const language = guessPrismLanguage(
       scopeForLanguageName(info.language),
       code,
@@ -135,7 +136,7 @@ function addLineNumbersIfNecessary($container, code: string): void {
  * @param highlight
  */
 function highlightLines(
-  $container: Cheerio,
+  $container: Cheerio<Element>,
   code: string,
   highlight: string | string[] | number,
 ): void {

--- a/src/render-enhancers/embedded-local-images.ts
+++ b/src/render-enhancers/embedded-local-images.ts
@@ -1,3 +1,4 @@
+import { CheerioAPI } from "cheerio";
 import { readFile } from "fs";
 import { extname } from "path";
 import { MarkdownEngineConfig } from "../markdown-engine-config";
@@ -7,7 +8,7 @@ import { removeFileProtocol } from "../utility";
  * Embed local images. Load the image file and display it in base64 format
  */
 export default async function enhance(
-  $: CheerioStatic,
+  $: CheerioAPI,
   options: MarkdownEngineConfig,
   resolveFilePath: (path: string, useRelativeFilePath: boolean) => string,
 ): Promise<void> {

--- a/src/render-enhancers/embedded-svgs.ts
+++ b/src/render-enhancers/embedded-svgs.ts
@@ -1,3 +1,4 @@
+import { CheerioAPI } from "cheerio";
 import { readFile } from "fs";
 import { extname } from "path";
 import { MarkdownEngineConfig } from "../mume";
@@ -8,7 +9,7 @@ import { removeFileProtocol } from "../utility";
  * @param $
  */
 export default async function enhance(
-  $: CheerioStatic,
+  $: CheerioAPI,
   options: MarkdownEngineConfig,
   resolveFilePath: (path: string, useRelativeFilePath: boolean) => string,
 ): Promise<void> {

--- a/src/render-enhancers/emoji-to-svg.ts
+++ b/src/render-enhancers/emoji-to-svg.ts
@@ -1,3 +1,4 @@
+import { CheerioAPI } from "cheerio";
 import { resolve } from "path";
 import * as twemoji from "twemoji";
 
@@ -5,7 +6,7 @@ import * as twemoji from "twemoji";
  * Replace emoji with svg.
  * @param $
  */
-export default function enhance($: CheerioStatic): void {
+export default function enhance($: CheerioAPI): void {
   const html = twemoji.parse($.html(), {
     callback: (icon) => {
       return (

--- a/src/render-enhancers/extended-table-syntax.ts
+++ b/src/render-enhancers/extended-table-syntax.ts
@@ -1,14 +1,16 @@
+import { Cheerio, CheerioAPI, Element } from "cheerio";
+
 /**
  * Extend table syntax to support colspan and rowspan for merging cells
  * @param $
  */
-export default async function enhance($): Promise<void> {
-  const rowspans: [Cheerio, Cheerio][] = []; // ^
-  const colspans: [Cheerio, Cheerio][] = []; // >
-  const colspans2: [Cheerio, Cheerio][] = []; // empty
+export default async function enhance($: CheerioAPI): Promise<void> {
+  const rowspans: [Cheerio<Element>, Cheerio<Element>][] = []; // ^
+  const colspans: [Cheerio<Element>, Cheerio<Element>][] = []; // >
+  const colspans2: [Cheerio<Element>, Cheerio<Element>][] = []; // empty
   $("table").each((i, table) => {
     const $table = $(table);
-    let $prevRow = null;
+    let $prevRow: Cheerio<Element> | null = null;
     $table.children().each((a, headBody) => {
       const $headBody = $(headBody);
       $headBody.children().each((i2, row) => {

--- a/src/render-enhancers/fenced-code-chunks.ts
+++ b/src/render-enhancers/fenced-code-chunks.ts
@@ -1,4 +1,5 @@
 // tslint:disable:ban-types no-var-requires
+import { Cheerio, CheerioAPI, Element } from "cheerio";
 import { run } from "../code-chunk";
 import { CodeChunkData, CodeChunksData } from "../code-chunk-data";
 import { BlockInfo } from "../lib/block-info";
@@ -7,7 +8,7 @@ import { toc } from "../toc";
 import { extractCommandFromBlockInfo } from "../utility";
 
 export default async function enhance(
-  $,
+  $: CheerioAPI,
   codeChunksData: CodeChunksData,
   renderOptions: MarkdownEngineRenderOption,
   runOptions: RunCodeChunkOptions,
@@ -20,7 +21,7 @@ export default async function enhance(
       return;
     }
 
-    const normalizedInfo: BlockInfo = $container.data("normalizedInfo");
+    const normalizedInfo = $container.data("normalizedInfo") as BlockInfo;
     if (!normalizedInfo.attributes["cmd"]) {
       return;
     }
@@ -43,9 +44,9 @@ export default async function enhance(
 }
 
 export async function renderCodeBlock(
-  $container: Cheerio,
+  $container: Cheerio<Element>,
   normalizedInfo: BlockInfo,
-  $: CheerioStatic,
+  $: CheerioAPI,
   codeChunksData: CodeChunksData,
   arrayOfCodeChunkData: CodeChunkData[],
   renderOptions: MarkdownEngineRenderOption,

--- a/src/render-enhancers/fenced-diagrams.ts
+++ b/src/render-enhancers/fenced-diagrams.ts
@@ -1,4 +1,5 @@
 // tslint:disable:ban-types no-var-requires
+import { Cheerio, CheerioAPI, Element } from "cheerio";
 import * as YAML from "yamljs";
 
 import { render as renderDitaa } from "../ditaa";
@@ -53,7 +54,7 @@ const supportedLanguages = [
  * @return html
  */
 export default async function enhance(
-  $,
+  $: CheerioAPI,
   graphsCache: { [key: string]: string },
   fileDirectoryPath: string,
   imageDirectoryPath: string,
@@ -66,7 +67,7 @@ export default async function enhance(
       return;
     }
 
-    const normalizedInfo: BlockInfo = $container.data("normalizedInfo");
+    const normalizedInfo = $container.data("normalizedInfo") as BlockInfo;
     if (
       normalizedInfo.attributes["literate"] === false ||
       normalizedInfo.attributes["cmd"] === false ||
@@ -97,9 +98,9 @@ export default async function enhance(
 }
 
 async function renderDiagram(
-  $container: Cheerio,
+  $container: Cheerio<Element>,
   normalizedInfo: BlockInfo,
-  $: CheerioStatic,
+  $: CheerioAPI,
   graphsCache: { [key: string]: string },
   fileDirectoryPath: string,
   imageDirectoryPath: string,

--- a/src/render-enhancers/fenced-math.ts
+++ b/src/render-enhancers/fenced-math.ts
@@ -1,3 +1,4 @@
+import { CheerioAPI } from "cheerio";
 import { stringifyBlockAttributes } from "../lib/block-attributes";
 import { BlockInfo } from "../lib/block-info";
 import { MathRenderingOption } from "../markdown-engine-config";
@@ -16,7 +17,7 @@ const supportedLanguages = ["math"];
  * @param $ cheerio element containing the entire document
  */
 export default async function enhance(
-  $,
+  $: CheerioAPI,
   renderingOption: MathRenderingOption,
   mathBlockDelimiters: string[][],
 ): Promise<void> {
@@ -26,7 +27,7 @@ export default async function enhance(
       return;
     }
 
-    const normalizedInfo: BlockInfo = $container.data("normalizedInfo");
+    const normalizedInfo = $container.data("normalizedInfo") as BlockInfo;
     if (
       normalizedInfo.attributes["literate"] === false ||
       normalizedInfo.attributes["cmd"] === false ||
@@ -56,7 +57,7 @@ export default async function enhance(
       $container.data("hiddenByEnhancer", true);
     }
   });
-  return $;
+  return;
 }
 
 const renderMath = (
@@ -64,7 +65,7 @@ const renderMath = (
   normalizedInfo: BlockInfo,
   renderingOption: MathRenderingOption,
   mathBlockDelimiters: string[][],
-): Cheerio => {
+): string => {
   let $output = null;
   try {
     const mathHtml = parseMath({

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -1,3 +1,4 @@
+import * as cheerio from "cheerio";
 import * as child_process from "child_process";
 import * as fs from "fs";
 import * as jsYAML from "js-yaml";
@@ -47,7 +48,7 @@ export interface ParserConfig {
   onWillParseMarkdown?: (markdown: string) => Promise<string>;
   onDidParseMarkdown?: (
     html: string,
-    opts: { cheerio: CheerioAPI },
+    opts: { cheerio: typeof cheerio },
   ) => Promise<string>;
   onWillTransformMarkdown?: (markdown: string) => Promise<string>;
   onDidTransformMarkdown?: (markdown: string) => Promise<string>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4149,10 +4149,10 @@ typedarray@^0.0.6:
   resolved "https://registry.npm.taobao.org/typedarray/download/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.4.3:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
-  integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
+typescript@^4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 unescape@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -560,13 +560,6 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/cheerio@0.22.11":
-  version "0.22.11"
-  resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.11.tgz#61c0facf9636d14ba5f77fc65ed8913aa845d717"
-  integrity sha512-x0X3kPbholdJZng9wDMhb2swvUi3UYRNAuWAmIPIWlfgAJZp//cql/qblE7181Mg7SjWVwq6ldCPCLn5AY/e7w==
-  dependencies:
-    "@types/node" "*"
-
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.npm.taobao.org/@types/events/download/@types/events-3.0.0.tgz?cache=0&sync_timestamp=1588200507611&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Fevents%2Fdownload%2F%40types%2Fevents-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -981,10 +974,10 @@ block-stream2@^2.0.0:
   dependencies:
     readable-stream "^3.4.0"
 
-boolbase@~1.0.0:
+boolbase@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.npm.taobao.org/boolbase/download/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
-  integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -1098,17 +1091,31 @@ char-regex@^1.0.2:
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
 
-cheerio@1.0.0-rc.3:
-  version "1.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.3.tgz#094636d425b2e9c0f4eb91a46c05630c9a1a8bf6"
-  integrity sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==
+cheerio-select@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cheerio-select/-/cheerio-select-2.1.0.tgz#4d8673286b8126ca2a8e42740d5e3c4884ae21b4"
+  integrity sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==
   dependencies:
-    css-select "~1.2.0"
-    dom-serializer "~0.1.1"
-    entities "~1.1.1"
-    htmlparser2 "^3.9.1"
-    lodash "^4.15.0"
-    parse5 "^3.0.1"
+    boolbase "^1.0.0"
+    css-select "^5.1.0"
+    css-what "^6.1.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.0.1"
+
+cheerio@^1.0.0-rc.11:
+  version "1.0.0-rc.11"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.11.tgz#1be84be1a126958366bcc57a11648cd9b30a60c2"
+  integrity sha512-bQwNaDIBKID5ts/DsdhxrjqFXYfLw4ste+wMKqWA8DyKcS4qwsPP4Bk8ZNaTJjvpiX/qW3BT4sU7d6Bh5i+dag==
+  dependencies:
+    cheerio-select "^2.1.0"
+    dom-serializer "^2.0.0"
+    domhandler "^5.0.3"
+    domutils "^3.0.1"
+    htmlparser2 "^8.0.1"
+    parse5 "^7.0.0"
+    parse5-htmlparser2-tree-adapter "^7.0.0"
+    tslib "^2.4.0"
 
 chrome-location@^1.2.1:
   version "1.2.1"
@@ -1280,20 +1287,21 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-css-select@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.npm.taobao.org/css-select/download/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
-  integrity sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=
+css-select@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
+  integrity sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==
   dependencies:
-    boolbase "~1.0.0"
-    css-what "2.1"
-    domutils "1.5.1"
-    nth-check "~1.0.1"
+    boolbase "^1.0.0"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    nth-check "^2.0.1"
 
-css-what@2.1:
-  version "2.1.3"
-  resolved "https://registry.npm.taobao.org/css-what/download/css-what-2.1.3.tgz?cache=0&sync_timestamp=1573341698559&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fcss-what%2Fdownload%2Fcss-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
-  integrity sha1-ptdgRXM2X+dGhsPzEcVlE9iChfI=
+css-what@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
+  integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
 
 cssom@^0.4.4:
   version "0.4.4"
@@ -1477,31 +1485,19 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-dom-serializer@0:
-  version "0.2.2"
-  resolved "https://registry.npm.taobao.org/dom-serializer/download/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
-  integrity sha1-GvuB9TNxcXXUeGVd68XjMtn5u1E=
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
   dependencies:
-    domelementtype "^2.0.1"
-    entities "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
 
-dom-serializer@~0.1.1:
-  version "0.1.1"
-  resolved "https://registry.npm.taobao.org/dom-serializer/download/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
-  integrity sha1-HsQFnihLq+027sKUHUqXChic58A=
-  dependencies:
-    domelementtype "^1.3.0"
-    entities "^1.1.1"
-
-domelementtype@1, domelementtype@^1.3.0, domelementtype@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.npm.taobao.org/domelementtype/download/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
-  integrity sha1-0EjESzew0Qp/Kj1f7j9DM9eQSB8=
-
-domelementtype@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npm.taobao.org/domelementtype/download/domelementtype-2.0.1.tgz#1f8bdfe91f5a78063274e803b4bdcedf6e94f94d"
-  integrity sha1-H4vf6R9aeAYydOgDtL3O326U+U0=
+domelementtype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
 
 domexception@^2.0.1:
   version "2.0.1"
@@ -1510,28 +1506,21 @@ domexception@^2.0.1:
   dependencies:
     webidl-conversions "^5.0.0"
 
-domhandler@^2.3.0:
-  version "2.4.2"
-  resolved "https://registry.npm.taobao.org/domhandler/download/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
-  integrity sha1-iAUJfpM9ZehVRvcm1g9euItE+AM=
+domhandler@^5.0.1, domhandler@^5.0.2, domhandler@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
   dependencies:
-    domelementtype "1"
+    domelementtype "^2.3.0"
 
-domutils@1.5.1:
-  version "1.5.1"
-  resolved "https://registry.npm.taobao.org/domutils/download/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
-  integrity sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=
+domutils@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.0.1.tgz#696b3875238338cb186b6c0612bd4901c89a4f1c"
+  integrity sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==
   dependencies:
-    dom-serializer "0"
-    domelementtype "1"
-
-domutils@^1.5.1:
-  version "1.7.0"
-  resolved "https://registry.npm.taobao.org/domutils/download/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
-  integrity sha1-Vuo0HoNOBuZ0ivehyyXaZ+qfjCo=
-  dependencies:
-    dom-serializer "0"
-    domelementtype "1"
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.1"
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -1580,15 +1569,10 @@ enquirer@^2.3.6:
   dependencies:
     ansi-colors "^4.1.1"
 
-entities@^1.1.1, entities@~1.1.1:
-  version "1.1.2"
-  resolved "https://registry.npm.taobao.org/entities/download/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
-  integrity sha1-vfpzUplmTfr9NFKe1PhSKidf6lY=
-
-entities@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.npm.taobao.org/entities/download/entities-2.0.2.tgz#ac74db0bba8d33808bbf36809c3a5c3683531436"
-  integrity sha1-rHTbC7qNM4CLvzaAnDpcNoNTFDY=
+entities@^4.2.0, entities@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.3.0.tgz#62915f08d67353bb4eb67e3d62641a4059aec656"
+  integrity sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg==
 
 errno@^0.1.1:
   version "0.1.7"
@@ -2037,17 +2021,15 @@ html-escaper@^2.0.0:
   resolved "https://registry.npm.taobao.org/html-escaper/download/html-escaper-2.0.2.tgz?cache=0&sync_timestamp=1585316700260&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhtml-escaper%2Fdownload%2Fhtml-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha1-39YAJ9o2o238viNiYsAKWCJoFFM=
 
-htmlparser2@^3.9.1:
-  version "3.10.1"
-  resolved "https://registry.npm.taobao.org/htmlparser2/download/htmlparser2-3.10.1.tgz?cache=0&sync_timestamp=1582422905208&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhtmlparser2%2Fdownload%2Fhtmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
-  integrity sha1-vWedw/WYl7ajS7EHSchVu1OpOS8=
+htmlparser2@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-8.0.1.tgz#abaa985474fcefe269bc761a779b544d7196d010"
+  integrity sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==
   dependencies:
-    domelementtype "^1.3.1"
-    domhandler "^2.3.0"
-    domutils "^1.5.1"
-    entities "^1.1.1"
-    inherits "^2.0.1"
-    readable-stream "^3.1.1"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    entities "^4.3.0"
 
 http-errors@1.7.3:
   version "1.7.3"
@@ -2190,7 +2172,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.npm.taobao.org/inherits/download/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=
@@ -2948,7 +2930,7 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash@4.x, lodash@^4.15.0, lodash@^4.17.15, lodash@^4.7.0:
+lodash@4.x, lodash@^4.17.15, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -3136,12 +3118,12 @@ npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
-nth-check@~1.0.1:
-  version "1.0.2"
-  resolved "https://registry.npm.taobao.org/nth-check/download/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
-  integrity sha1-sr0pXDfj3VijvwcAN2Zjuk2c8Fw=
+nth-check@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-2.1.1.tgz#c9eab428effce36cd6b92c924bdb000ef1f1ed1d"
+  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
   dependencies:
-    boolbase "~1.0.0"
+    boolbase "^1.0.0"
 
 nwsapi@^2.2.0:
   version "2.2.0"
@@ -3267,17 +3249,25 @@ parse-json@^5.0.0:
     json-parse-better-errors "^1.0.1"
     lines-and-columns "^1.1.6"
 
+parse5-htmlparser2-tree-adapter@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz#23c2cc233bcf09bb7beba8b8a69d46b08c62c2f1"
+  integrity sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==
+  dependencies:
+    domhandler "^5.0.2"
+    parse5 "^7.0.0"
+
 parse5@6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
-parse5@^3.0.1:
-  version "3.0.3"
-  resolved "https://registry.npm.taobao.org/parse5/download/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
-  integrity sha1-BC95L/3TaFFVHPTp4Gazh0q0W1w=
+parse5@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.0.0.tgz#51f74a5257f5fcc536389e8c2d0b3802e1bfa91a"
+  integrity sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==
   dependencies:
-    "@types/node" "*"
+    entities "^4.3.0"
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -3523,7 +3513,7 @@ readable-stream@2, readable-stream@^2.2.2:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.1.1, readable-stream@^3.4.0:
+readable-stream@^3.4.0:
   version "3.6.0"
   resolved "https://registry.npm.taobao.org/readable-stream/download/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha1-M3u9o63AcGvT4CRCaihtS0sskZg=
@@ -4061,6 +4051,11 @@ tslib@^1.10.0, tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tslint-config-prettier@^1.18.0:
   version "1.18.0"


### PR DESCRIPTION
fix #267 

I upgraded cheerio to v1.0.0-rc.11 to fix [CVE-2021-3803](https://github.com/advisories/GHSA-rp65-9cf3-cjxr).
cheerio using [a new syntax in TypeScript 4.5](https://devblogs.microsoft.com/typescript/announcing-typescript-4-5/#type-on-import-names), so I had to upgrade TypeScript version.
