### PR TITLE
add typescript extension in code trunk, also use lauguage name as fal…

### DIFF
--- a/src/code-chunk.ts
+++ b/src/code-chunk.ts
@@ -175,8 +175,9 @@ const fileExtensionMap = {
   go: ".go",
   javascript: ".js",
   python: ".py",
+  typescript: ".ts",
 };
 
 function getFileExtension(language: string): string {
-  return fileExtensionMap[language] || "";
+  return fileExtensionMap[language] || `.{language}`;
 }


### PR DESCRIPTION
add typescript extension in code trunk, also use language name as fallback extension.

The reason for the modification is that below code cannot be executed as typescript, due to lack of extension in the generated code trunk file.

```ts {cmd="ts-node"}
let aTypeScriptVar: string ;
console.log(aTypeScriptVar);
```

with below error

```
/Users/.....docs/home/ubrz0nkgd_code_chunk:1
let aTypeScriptVar: string ;
                  ^

SyntaxError: Unexpected token ':'
    at Object.compileFunction (node:vm:352:18)
    at wrapSafe (node:internal/modules/cjs/loader:1031:15)
    at Module._compile (node:internal/modules/cjs/loader:1065:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Object.require.extensions. [as .js] (/usr/local/lib/node_modules/ts-node/src/index.ts:1608:43)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at phase4 (/usr/local/lib/node_modules/ts-node/src/bin.ts:649:14)
    at bootstrap (/usr/local/lib/node_modules/ts-node/src/bin.ts:95:10)
```