### PR TITLE
add node and ts-node in file extension map

### DIFF
--- a/src/code-chunk.ts
+++ b/src/code-chunk.ts
@@ -176,8 +176,10 @@ const fileExtensionMap = {
   javascript: ".js",
   python: ".py",
   typescript: ".ts",
+  node: ".js",
+  "ts-node": ".ts",
 };
 
-function getFileExtension(language: string): string {
-  return fileExtensionMap[language] || `.${language}`;
+function getFileExtension(cmd: string): string {
+  return fileExtensionMap[cmd] || `.${cmd}`;
 }


### PR DESCRIPTION
Added node and ts-node in the file-extension map.

I realized actually the index in the map is actaully not 'language' but the 'cmd'.