### PR TITLE
fix: Match GitHub markdown header IDs

### DIFF
--- a/src/heading-id-generator.ts
+++ b/src/heading-id-generator.ts
@@ -6,8 +6,22 @@ export default class HeadingIdGenerator {
     this.table = {};
   }
   public generateId(heading: string): string {
-    heading = heading.replace(/。/g, ""); // sanitize
-    let slug = uslug(heading);
+    const replacement = (match: string, capture: string): string => {
+      let sanitized = capture
+        .replace(/[!"#$%&'()*+,./:;<=>?@[\\]^`{|}~]/g, "")
+        .replace(/^\s/, "")
+        .replace(/\s$/, "")
+        .replace(/`/g, "~");
+      return (
+        (capture.match(/^\s+$/) ? "~" : sanitized) +
+        (match.endsWith(" ") && !sanitized.endsWith("~") ? "~" : "")
+      );
+    };
+    heading = heading
+      .replace(/~|。/g, "") // sanitize
+      .replace(/``(.+?)``\s?/g, replacement)
+      .replace(/`(.*?)`\s?/g, replacement);
+    let slug = uslug(heading.replace(/\s/g, "~")).replace(/~/g, "-");
     if (this.table[slug] >= 0) {
       this.table[slug] = this.table[slug] + 1;
       slug += "-" + this.table[slug];

--- a/test/header-id-generator.test.ts
+++ b/test/header-id-generator.test.ts
@@ -1,0 +1,74 @@
+import HeadingIdGenerator from "../src/heading-id-generator";
+
+const testCasesForHeaderIdGenerator: {
+  input: string;
+  expected: string;
+}[] = [
+  {
+    input: "Hello world!",
+    expected: "hello-world",
+  },
+  {
+    input: "Hello, world!",
+    expected: "hello-world-1",
+  },
+  {
+    input: "foo0 ~  bar",
+    expected: "foo0---bar",
+  },
+  {
+    input: "foo1 `,` bar",
+    expected: "foo1--bar",
+  },
+  {
+    input: "foo2 `` bar",
+    expected: "foo2--bar",
+  },
+  {
+    input: "foo3 `` ` `` bar",
+    expected: "foo3--bar",
+  },
+  {
+    input: "foo4 `` abc`def `` bar",
+    expected: "foo4-abc-def-bar",
+  },
+  {
+    input: "foo5 `` `` bar",
+    expected: "foo5---bar",
+  },
+  {
+    input: "foo6 `,-!(){}[]` bar",
+    expected: "foo6---bar",
+  },
+  {
+    input: "foo7 `abc-def` bar",
+    expected: "foo7-abc-def-bar",
+  },
+  {
+    input: "foo8 `.` `.` `.` `.` `.` bar",
+    expected: "foo8------bar",
+  },
+  {
+    input: "foo9 `` `` `` `` `` bar",
+    expected: "foo9------bar",
+  },
+  {
+    input: "foo10` , `bar",
+    expected: "foo10bar",
+  },
+  {
+    input: "foo11!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~bar",
+    expected: "foo11-_bar",
+  },
+];
+
+describe("header-id-generator", () => {
+  const headerIdGenerator = new HeadingIdGenerator();
+
+  testCasesForHeaderIdGenerator.map(({ input, expected }) => {
+    it(`generates header ID for ${input} correctly`, () => {
+      const actual: string = headerIdGenerator.generateId(input);
+      expect(actual).toEqual(expected);
+    });
+  });
+});


### PR DESCRIPTION
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`703a3d7`](https://github.com/shd101wyy/mume/pull/284/commits/703a3d73687ebc872fe1f5576445b0aab81ccc62) fix: Match GitHub markdown header IDs

First, GitHub doesn't squash consecutive spaces. This is hard-coded in
uslug [1] and I put together a workaround by leveraging ~ (tilde), which
is actually not allowed in GitHub header IDs but allowed by uslug [2].

Second, GitHub has some quirks for single/double-backtick-quoted
strings. I replaced them before calling uslug.

[1] https://github.com/jeremys/uslug/blob/a58c4aedd5e13b2c1ad852d5e776b1e4cd7756c0/lib/uslug.js#L53
[2] https://github.com/jeremys/uslug/blob/a58c4aedd5e13b2c1ad852d5e776b1e4cd7756c0/lib/uslug.js#L19


<!-- === GH HISTORY FENCE === -->

---

This is to tackle https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/662
