### PR TITLE
fix: Remove surrounding hyphens in header IDs

### DIFF
--- a/src/heading-id-generator.ts
+++ b/src/heading-id-generator.ts
@@ -18,6 +18,7 @@ export default class HeadingIdGenerator {
       );
     };
     heading = heading
+      .trim()
       .replace(/~|。/g, "") // sanitize
       .replace(/``(.+?)``\s?/g, replacement)
       .replace(/`(.*?)`\s?/g, replacement);

--- a/test/header-id-generator.test.ts
+++ b/test/header-id-generator.test.ts
@@ -9,6 +9,14 @@ const testCasesForHeaderIdGenerator: {
     expected: "hello-world",
   },
   {
+    input: "  Leading space world!",
+    expected: "leading-space-world",
+  },
+  {
+    input: "Trailing space world!   ",
+    expected: "trailing-space-world",
+  },
+  {
     input: "Hello, world!",
     expected: "hello-world-1",
   },


### PR DESCRIPTION
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`f0b8ade`](https://github.com/shd101wyy/mume/pull/287/commits/f0b8ade236c6f8108003dc7474653158626c7d8a) fix: Remove surrounding hyphens in header IDs

This is an issue introduced in my [1]. Apparently uslug() trimmed inputs
by default so that leading/trailing spaces don't get converted to
hyphens.

[1] https://github.com/shd101wyy/mume/commit/703a3d73687ebc872fe1f5576445b0aab81ccc62


<!-- === GH HISTORY FENCE === -->
