### PR TITLE
Fix SVG file path by removing random parameter

### DIFF
--- a/src/tools/pdf.ts
+++ b/src/tools/pdf.ts
@@ -78,7 +78,6 @@ export function toSVGMarkdown(
           });
 
           let svgMarkdown = '';
-          const r = Math.random();
 
           items.forEach((fileName) => {
             const match = fileName.match(
@@ -115,7 +114,7 @@ export function toSVGMarkdown(
                   svgZoom ? `style="zoom:${svgZoom};"` : ''
                 }>`;
               } else {
-                svgMarkdown += `![](${svgFilePath}?${r})\n`;
+                svgMarkdown += `![](${svgFilePath})\n`;
               }
             }
           });


### PR DESCRIPTION
Removed random query parameter from SVG file path.

svgFilePath should already be unique so the random parameter is not needed. However the random parameter causes 
https://github.com/shd101wyy/crossnote/issues/375
https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/1847
https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/2195
https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/1878