### PR TITLE
Add D2 diagram rendering support

### DIFF
--- a/build.js
+++ b/build.js
@@ -15,6 +15,7 @@ const sharedConfig = {
     'path',
     'child_process',
     'os',
+    'crypto',
     'vm',
     'stream',
     'node:fs/promises',

--- a/src/lib/block-info/parse-block-info.ts
+++ b/src/lib/block-info/parse-block-info.ts
@@ -6,19 +6,57 @@ export const parseBlockInfo = (raw = ''): BlockInfo => {
   let attributesAsString: string;
   let attributes: BlockAttributes;
   const trimmedParams = raw.trim();
-  const match =
-    trimmedParams.indexOf('{') !== -1
-      ? trimmedParams.match(/^([^\s{]*)\s*\{(.*?)\}/)
-      : trimmedParams.match(/^([^\s]+)\s+(.+?)$/);
-
-  if (match) {
-    if (match[1].length) {
-      language = match[1];
+  if (trimmedParams.indexOf('{') !== -1) {
+    // The transformer appends {data-source-line="N"} to fence info strings,
+    // producing either:
+    //   "lang {attrs} {data-source-line="N"}"  (when attrs already existed)
+    //   "lang pre-attrs {data-source-line="N"}" (space-separated attrs like d2)
+    //   "lang {attrs}"                          (normal case)
+    // Strategy: extract language (up to first space or {), then collect all
+    // brace-group contents and space-separated tokens between them as attrs.
+    const langMatch = trimmedParams.match(/^([^\s{]*)/);
+    if (langMatch?.[1].length) {
+      language = langMatch[1];
     }
-    attributesAsString = match[2];
+    const afterLang = trimmedParams.slice(language?.length ?? 0).trim();
+    // Collect all {…} blocks and bare tokens between them
+    const attrParts: string[] = [];
+    let rest = afterLang;
+    while (rest.length) {
+      const braceStart = rest.indexOf('{');
+      if (braceStart === -1) {
+        // remaining bare tokens
+        const bare = rest.trim();
+        if (bare) attrParts.push(bare);
+        break;
+      }
+      // bare tokens before the brace
+      const bare = rest.slice(0, braceStart).trim();
+      if (bare) attrParts.push(bare);
+      // find matching closing brace
+      let depth = 1;
+      let i = braceStart + 1;
+      while (i < rest.length && depth > 0) {
+        if (rest[i] === '{') depth++;
+        else if (rest[i] === '}') depth--;
+        i++;
+      }
+      const braceContent = rest.slice(braceStart + 1, i - 1).trim();
+      if (braceContent) attrParts.push(braceContent);
+      rest = rest.slice(i).trim();
+    }
+    attributesAsString = attrParts.join(' ');
   } else {
-    language = trimmedParams;
-    attributesAsString = '';
+    const match = trimmedParams.match(/^([^\s]+)\s+(.+?)$/);
+    if (match) {
+      if (match[1].length) {
+        language = match[1];
+      }
+      attributesAsString = match[2];
+    } else {
+      language = trimmedParams;
+      attributesAsString = '';
+    }
   }
 
   if (attributesAsString) {

--- a/src/lib/block-info/parse-block-info.ts
+++ b/src/lib/block-info/parse-block-info.ts
@@ -7,13 +7,16 @@ export const parseBlockInfo = (raw = ''): BlockInfo => {
   let attributes: BlockAttributes;
   const trimmedParams = raw.trim();
   if (trimmedParams.indexOf('{') !== -1) {
-    // The transformer appends {data-source-line="N"} to fence info strings,
-    // producing either:
-    //   "lang {attrs} {data-source-line="N"}"  (when attrs already existed)
-    //   "lang pre-attrs {data-source-line="N"}" (space-separated attrs like d2)
-    //   "lang {attrs}"                          (normal case)
-    // Strategy: extract language (up to first space or {), then collect all
-    // brace-group contents and space-separated tokens between them as attrs.
+    // The transformer appends {data-source-line="N"} to fence info strings.
+    // Depending on whether the fence already had attrs, it produces one of:
+    //
+    //   "lang {attrs data-source-line="N"}"       ← brace-attrs merged with source line
+    //   "lang space-attrs {data-source-line="N"}" ← space-attrs with source line appended
+    //   "lang {data-source-line="N"}"             ← no prior attrs, source line only
+    //   "lang {attrs}"                            ← no source tracking (normal case)
+    //
+    // Strategy: extract the language token (up to first space or '{'), then
+    // gather all brace-group contents and bare space-separated tokens as attrs.
     const langMatch = trimmedParams.match(/^([^\s{]*)/);
     if (langMatch?.[1].length) {
       language = langMatch[1];

--- a/src/markdown-engine/index.ts
+++ b/src/markdown-engine/index.ts
@@ -370,7 +370,7 @@ if (typeof(window['Reveal']) !== 'undefined') {
     presentationInitScript = `<script>
 window["initRevealPresentation"] = async function() {
   ${presentationInitScript}
-}    
+}
 </script>`;
 
     return scripts + presentationInitScript;
@@ -687,7 +687,7 @@ window["initRevealPresentation"] = async function() {
   pre code {
     color: var(--vscode-editor-foreground);
     tab-size: 4;
-  }  
+  }
   </style>
 `
             : ''
@@ -2634,6 +2634,10 @@ sidebarTOCBtn.addEventListener('click', function(event) {
       kirokiServer: this.notebook.config.krokiServer,
       webSequenceDiagramsServer: this.notebook.config.webSequenceDiagramsServer,
       webSequenceDiagramsApiKey: this.notebook.config.webSequenceDiagramsApiKey,
+      d2Path: this.notebook.config.d2Path,
+      d2Layout: this.notebook.config.d2Layout,
+      d2Theme: this.notebook.config.d2Theme,
+      d2Sketch: this.notebook.config.d2Sketch,
     });
     await enhanceWithFencedCodeChunks(
       $,

--- a/src/notebook/types.ts
+++ b/src/notebook/types.ts
@@ -492,6 +492,30 @@ export interface NotebookConfig {
    */
   webSequenceDiagramsApiKey: string;
   /**
+   * Path to the D2 executable.
+   *
+   * @default `d2`
+   */
+  d2Path: string;
+  /**
+   * Default layout engine for D2 diagrams.
+   *
+   * @default `dagre`
+   */
+  d2Layout: string;
+  /**
+   * Default theme ID for D2 diagrams.
+   *
+   * @default 0
+   */
+  d2Theme: number;
+  /**
+   * Whether to render D2 diagrams in sketch (hand-drawn) style.
+   *
+   * @default false
+   */
+  d2Sketch: boolean;
+  /**
    * Whether the current environment is VSCode.
    *
    * @default false
@@ -600,6 +624,10 @@ export function getDefaultNotebookConfig(): NotebookConfig {
     krokiServer: 'https://kroki.io',
     webSequenceDiagramsServer: 'https://www.websequencediagrams.com',
     webSequenceDiagramsApiKey: '',
+    d2Path: 'd2',
+    d2Layout: 'dagre',
+    d2Theme: 0,
+    d2Sketch: false,
     isVSCode: false,
     alwaysShowBacklinksInPreview: false,
   };

--- a/src/render-enhancers/fenced-diagrams.ts
+++ b/src/render-enhancers/fenced-diagrams.ts
@@ -9,6 +9,7 @@ import {
 import { BlockInfo } from '../lib/block-info';
 import computeChecksum from '../lib/compute-checksum';
 import { renderBitfield } from '../renderers/bitfield';
+import { D2_NOT_FOUND, renderD2 } from '../renderers/d2';
 import { render as renderPlantuml } from '../renderers/puml';
 import { toSVG as vegaToSvg } from '../renderers/vega';
 import { toSVG as vegaLiteToSvg } from '../renderers/vega-lite';
@@ -46,6 +47,7 @@ const supportedLanguages = [
   'vega',
   'vega-lite',
   'wsd',
+  'd2',
 ];
 
 /**
@@ -63,6 +65,10 @@ export default async function enhance({
   kirokiServer,
   webSequenceDiagramsServer,
   webSequenceDiagramsApiKey,
+  d2Path,
+  d2Layout,
+  d2Theme,
+  d2Sketch,
 }: {
   $: CheerioStatic;
   graphsCache: { [key: string]: string };
@@ -73,9 +79,14 @@ export default async function enhance({
   kirokiServer: string;
   webSequenceDiagramsServer: string;
   webSequenceDiagramsApiKey: string;
+  d2Path: string;
+  d2Layout: string;
+  d2Theme: number;
+  d2Sketch: boolean;
 }): Promise<void> {
   const asyncFunctions: Promise<void>[] = [];
-  $('[data-role="codeBlock"]').each((i, container) => {
+  const allBlocks = $('[data-role="codeBlock"]');
+  allBlocks.each((i, container) => {
     const $container = $(container);
     if ($container.data('executor')) {
       return;
@@ -115,6 +126,10 @@ export default async function enhance({
         kirokiServer,
         webSequenceDiagramsServer,
         webSequenceDiagramsApiKey,
+        d2Path,
+        d2Layout,
+        d2Theme,
+        d2Sketch,
       }),
     );
   });
@@ -133,6 +148,10 @@ async function renderDiagram({
   kirokiServer,
   webSequenceDiagramsServer,
   webSequenceDiagramsApiKey,
+  d2Path,
+  d2Layout,
+  d2Theme,
+  d2Sketch,
 }: {
   $container: Cheerio;
   normalizedInfo: BlockInfo;
@@ -146,6 +165,10 @@ async function renderDiagram({
   kirokiServer: string;
   webSequenceDiagramsServer: string;
   webSequenceDiagramsApiKey: string;
+  d2Path: string;
+  d2Layout: string;
+  d2Theme: number;
+  d2Sketch: boolean;
 }): Promise<void> {
   let $output: string | Cheerio | null = null;
 
@@ -313,6 +336,42 @@ async function renderDiagram({
           $output = `<div ${stringifyBlockAttributes(
             ensureClassInAttributes(normalizedInfo.attributes, 'wsd'),
           )}><img src="${escape(imgUrl)}" alt="Sequence Diagram"></div>`;
+          break;
+        }
+        case 'd2': {
+          // Per-block overrides are parsed by crossnote's block-info parser
+          // from the fence info string (e.g. ```d2 layout=elk theme=200 sketch)
+          // and stored as typed values in normalizedInfo.attributes.
+          const renderOpts = {
+            d2Path: d2Path || 'd2',
+            d2Layout:
+              (normalizedInfo.attributes['layout'] as string) ||
+              d2Layout ||
+              'dagre',
+            d2Theme:
+              (normalizedInfo.attributes['theme'] as number) ?? d2Theme ?? 0,
+            d2Sketch:
+              'sketch' in normalizedInfo.attributes
+                ? normalizedInfo.attributes['sketch'] === true
+                : (d2Sketch ?? false),
+          };
+          // Include resolved render options in the checksum so that changes to
+          // global d2 settings (layout/theme/sketch) correctly bust the cache,
+          // consistent with how per-fence attributes already do via normalizedInfo.
+          const d2Checksum = computeChecksum(
+            JSON.stringify(normalizedInfo) + code + JSON.stringify(renderOpts),
+          );
+          const d2DiagramInCache: string = graphsCache[d2Checksum];
+          if (!d2DiagramInCache) {
+            const result = await renderD2(code, renderOpts);
+            if (result !== D2_NOT_FOUND) {
+              graphsCache[d2Checksum] = result as string;
+              $output = `<div class="d2-diagram">${result}</div>`;
+            }
+            // D2_NOT_FOUND: leave block as-is (d2 not installed)
+          } else {
+            $output = `<div class="d2-diagram">${d2DiagramInCache}</div>`;
+          }
           break;
         }
       }

--- a/src/renderers/d2.ts
+++ b/src/renderers/d2.ts
@@ -1,0 +1,85 @@
+// These imports are Node.js-only. In web/browser environments they are either
+// unavailable or polyfilled as empty stubs. We guard all usage below so that
+// the web extension gracefully falls back to a plain code block.
+import { execFile } from 'child_process';
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+export interface D2RenderOptions {
+  d2Path: string;
+  d2Layout: string;
+  d2Theme: number;
+  d2Sketch: boolean;
+}
+
+/**
+ * Returned when the d2 binary is not found — callers should leave the
+ * original code block in place rather than showing an error.
+ */
+export const D2_NOT_FOUND = Symbol('D2_NOT_FOUND');
+
+/**
+ * Render a D2 diagram source string to SVG by shelling out to the `d2` CLI.
+ * Returns `D2_NOT_FOUND` if the binary is not installed, or an HTML error
+ * string if d2 is installed but returns an error.
+ */
+export async function renderD2(
+  code: string,
+  opts: D2RenderOptions,
+): Promise<string | typeof D2_NOT_FOUND> {
+  // Guard: in browser/web environments, crypto.randomBytes is not available.
+  if (typeof crypto?.randomBytes !== 'function') return D2_NOT_FOUND;
+
+  const id = crypto.randomBytes(8).toString('hex');
+  const tmpIn = path.join(os.tmpdir(), `d2-${id}.d2`);
+  const tmpOut = path.join(os.tmpdir(), `d2-${id}.svg`);
+
+  try {
+    await fs.promises.writeFile(tmpIn, code, 'utf8');
+    await new Promise<void>((resolve, reject) => {
+      const args = [
+        `--theme=${opts.d2Theme}`,
+        `--layout=${opts.d2Layout}`,
+        ...(opts.d2Sketch ? ['--sketch'] : []),
+        tmpIn,
+        tmpOut,
+      ];
+      execFile(
+        opts.d2Path,
+        args,
+        { timeout: 30000 },
+        (err, _stdout, stderr) => {
+          if (err) {
+            const wrapped = new Error(stderr || err.message) as Error & {
+              code?: string;
+            };
+            wrapped.code = (err as NodeJS.ErrnoException).code;
+            reject(wrapped);
+          } else {
+            resolve();
+          }
+        },
+      );
+    });
+    return await fs.promises.readFile(tmpOut, 'utf8');
+  } catch (err: any) {
+    // d2 binary not found — caller falls back to plain code block.
+    // On Windows with shell:true, cmd.exe exits with code 1 and prints
+    // "is not recognized..." instead of an OS-level ENOENT.
+    const msg: string = err?.message ?? String(err);
+    const isNotFound =
+      err?.code === 'ENOENT' ||
+      /not recognized as an internal or external command/i.test(msg) ||
+      /not found/i.test(msg) ||
+      /cannot find/i.test(msg) ||
+      /No such file or directory/i.test(msg);
+    if (isNotFound) return D2_NOT_FOUND;
+    const escaped = msg.replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    return `<pre class="language-text"><code>D2 error: ${escaped}</code></pre>`;
+  } finally {
+    fs.promises.unlink(tmpIn).catch(() => undefined);
+    fs.promises.unlink(tmpOut).catch(() => undefined);
+  }
+}

--- a/src/renderers/d2.ts
+++ b/src/renderers/d2.ts
@@ -3,6 +3,7 @@
 // the web extension gracefully falls back to a plain code block.
 import { execFile } from 'child_process';
 import * as crypto from 'crypto';
+import { escape } from 'html-escaper';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -64,20 +65,20 @@ export async function renderD2(
       );
     });
     return await fs.promises.readFile(tmpOut, 'utf8');
-  } catch (err: any) {
+  } catch (err: unknown) {
     // d2 binary not found — caller falls back to plain code block.
-    // On Windows with shell:true, cmd.exe exits with code 1 and prints
-    // "is not recognized..." instead of an OS-level ENOENT.
-    const msg: string = err?.message ?? String(err);
+    // Some Windows environments report a missing executable via stderr text
+    // such as "is not recognized..." instead of an OS-level ENOENT.
+    const msg = err instanceof Error ? err.message : String(err);
+    const code = (err as NodeJS.ErrnoException).code;
     const isNotFound =
-      err?.code === 'ENOENT' ||
+      code === 'ENOENT' ||
       /not recognized as an internal or external command/i.test(msg) ||
       /not found/i.test(msg) ||
       /cannot find/i.test(msg) ||
       /No such file or directory/i.test(msg);
     if (isNotFound) return D2_NOT_FOUND;
-    const escaped = msg.replace(/</g, '&lt;').replace(/>/g, '&gt;');
-    return `<pre class="language-text"><code>D2 error: ${escaped}</code></pre>`;
+    return `<pre class="language-text"><code>D2 error: ${escape(msg)}</code></pre>`;
   } finally {
     fs.promises.unlink(tmpIn).catch(() => undefined);
     fs.promises.unlink(tmpOut).catch(() => undefined);

--- a/test/lib/block-info.test.ts
+++ b/test/lib/block-info.test.ts
@@ -125,9 +125,10 @@ const testCasesForParseBlockInfo: {
       },
     },
   },
-  // Transformer output when original attrs were in braces: lang {attrs} {data-source-line="N"}
+  // Transformer output when original attrs were in braces: merged into single group
+  // lang {attrs data-source-line="N"}
   {
-    input: 'd2 {layout=elk theme=200} {data-source-line="5"}',
+    input: 'd2 {layout=elk theme=200 data-source-line="5"}',
     expect: {
       language: 'd2',
       attributes: {
@@ -136,6 +137,14 @@ const testCasesForParseBlockInfo: {
         'theme': 200,
         'data-source-line': '5',
       },
+    },
+  },
+  // Transformer output when fence had no prior attrs: lang {data-source-line="N"}
+  {
+    input: 'd2 {data-source-line="5"}',
+    expect: {
+      language: 'd2',
+      attributes: { 'class': 'd2', 'data-source-line': '5' },
     },
   },
 ];

--- a/test/lib/block-info.test.ts
+++ b/test/lib/block-info.test.ts
@@ -103,6 +103,41 @@ const testCasesForParseBlockInfo: {
       attributes: { just: 'attribute', class: 'html python js' },
     },
   },
+  // D2-style space-separated attributes (no braces)
+  {
+    input: 'd2 layout=elk theme=200 sketch',
+    expect: {
+      language: 'd2',
+      attributes: { class: 'd2', layout: 'elk', theme: 200, sketch: true },
+    },
+  },
+  // Transformer output for d2 block: space-attrs + appended {data-source-line="N"}
+  {
+    input: 'd2 layout=elk theme=200 sketch {data-source-line="5"}',
+    expect: {
+      language: 'd2',
+      attributes: {
+        'class': 'd2',
+        'layout': 'elk',
+        'theme': 200,
+        'sketch': true,
+        'data-source-line': '5',
+      },
+    },
+  },
+  // Transformer output when original attrs were in braces: lang {attrs} {data-source-line="N"}
+  {
+    input: 'd2 {layout=elk theme=200} {data-source-line="5"}',
+    expect: {
+      language: 'd2',
+      attributes: {
+        'class': 'd2',
+        'layout': 'elk',
+        'theme': 200,
+        'data-source-line': '5',
+      },
+    },
+  },
 ];
 
 const testCasesForNormalizeCodeBlockInfo: {


### PR DESCRIPTION
## Add D2 diagram rendering support

Adds support for rendering [D2](https://d2lang.com) diagrams by shelling out to the `d2` CLI.

### Changes

- **`src/renderers/d2.ts`** — New renderer: writes diagram source to a temp file, invokes the `d2` CLI, reads back the SVG. Returns a `D2_NOT_FOUND` symbol when the binary is not installed (callers render as plain code block). Web/browser environments are guarded and also return `D2_NOT_FOUND`.

- **`src/notebook/types.ts`** — Added `d2Path`, `d2Layout`, `d2Theme`, `d2Sketch` to `NotebookConfig` with defaults (`d2`, `dagre`, `0`, `false`).

- **`src/markdown-engine/index.ts`** — Passes d2 config fields through to `enhanceWithFencedDiagrams`.

- **`src/render-enhancers/fenced-diagrams.ts`** — Added `'d2'` to supported languages and a `case 'd2'` handler. Per-fence attributes (`layout`, `theme`, `sketch`) override global config. Uses a d2-specific cache key that includes the resolved render options so global setting changes correctly bust the cache.

- **`src/lib/block-info/parse-block-info.ts`** — Fixed `parseBlockInfo` to correctly handle fence info strings of the form `lang space-attrs {brace-attrs}` and `lang {attrs1} {attrs2}`. The transformer appends `{data-source-line="N"}` to fence info strings that already have space-separated attributes (e.g. `` ```d2 layout=elk theme=200 sketch ``), which the old single-regex approach failed to parse correctly.

- **`build.js`** — Added `crypto` to Node built-in externals (used by the new d2 renderer).

### Usage (in the host editor)

~~~markdown
```d2
shape: sequence_diagram
alice -> bob: What does it mean?
bob -> alice: 42
```
~~~

Per-block overrides:

~~~markdown
```d2 layout=elk theme=200 sketch
...
```
~~~