### PR TITLE
feat: add support for colon-fenced code blocks (Azure DevOps)

### DIFF
--- a/src/custom-markdown-it-features/code-fences.ts
+++ b/src/custom-markdown-it-features/code-fences.ts
@@ -6,33 +6,44 @@
 // tslint:disable-next-line no-implicit-dependencies
 import { escape } from 'html-escaper';
 import MarkdownIt from 'markdown-it';
+import Token from 'markdown-it/lib/token';
 import { normalizeBlockInfo, parseBlockInfo } from '../lib/block-info';
 
+/**
+ * Shared renderer for both backtick-fenced and colon-fenced code blocks.
+ * Produces `<pre data-role="codeBlock" ...>` output consumed by the
+ * render-enhancer pipeline (fenced-diagrams, fenced-code-chunks, etc.).
+ */
+export function renderCodeBlockToken(tokens: Token[], idx: number): string {
+  const token = tokens[idx];
+
+  // get code info (same line as opening fence)
+  const info = token.info.trim();
+  const parsedInfo = parseBlockInfo(info);
+  const normalizedInfo = normalizeBlockInfo(parsedInfo);
+
+  // get code content
+  const content = escape(token.content);
+
+  // Add a trailing newline when the next token closes a list item so that the
+  // rendered HTML does not run into the closing </li> tag.
+  const finalBreak =
+    idx + 1 < tokens.length && tokens[idx + 1].type === 'list_item_close'
+      ? '\n'
+      : '';
+
+  // NOTE: The actual <code> tag is added in the code-block-styling.ts.
+  return `<pre data-role="codeBlock" data-info="${escape(
+    info,
+  )}" data-parsed-info="${escape(
+    JSON.stringify(parsedInfo),
+  )}" data-normalized-info="${escape(JSON.stringify(normalizedInfo))}" ${
+    'data-source-line' in parsedInfo.attributes
+      ? `data-source-line="${parsedInfo.attributes['data-source-line']}"`
+      : ''
+  }>${content}</pre>${finalBreak}`;
+}
+
 export default (md: MarkdownIt) => {
-  md.renderer.rules.fence = (tokens, idx) => {
-    const token = tokens[idx];
-
-    // get code info (same line as opening fence)
-    const info = token.info.trim();
-    const parsedInfo = parseBlockInfo(info);
-    const normalizedInfo = normalizeBlockInfo(parsedInfo);
-
-    // get code content
-    const content = escape(token.content);
-
-    // copied from getBreak function.
-    const finalBreak =
-      idx < tokens.length && tokens[idx].type === 'list_item_close' ? '\n' : '';
-
-    // NOTE: The actual <code> tag is added in the code-block-styling.ts.
-    return `<pre data-role="codeBlock" data-info="${escape(
-      info,
-    )}" data-parsed-info="${escape(
-      JSON.stringify(parsedInfo),
-    )}" data-normalized-info="${escape(JSON.stringify(normalizedInfo))}" ${
-      'data-source-line' in parsedInfo.attributes
-        ? `data-source-line="${parsedInfo.attributes['data-source-line']}"`
-        : ''
-    }>${content}</pre>${finalBreak}`;
-  };
+  md.renderer.rules.fence = renderCodeBlockToken;
 };

--- a/src/custom-markdown-it-features/colon-fenced-code-blocks.ts
+++ b/src/custom-markdown-it-features/colon-fenced-code-blocks.ts
@@ -12,9 +12,8 @@
  * rendering pipeline.
  */
 
-import { escape } from 'html-escaper';
 import MarkdownIt from 'markdown-it';
-import { normalizeBlockInfo, parseBlockInfo } from '../lib/block-info';
+import { renderCodeBlockToken } from './code-fences';
 
 export default (md: MarkdownIt) => {
   // Block rule: parse :::type ... ::: fences
@@ -22,29 +21,10 @@ export default (md: MarkdownIt) => {
     alt: ['paragraph', 'reference', 'blockquote', 'list'],
   });
 
-  // Renderer: produce the same <pre data-role="codeBlock"> output as
-  // code-fences.ts so the existing render-enhancer pipeline (fenced-diagrams,
-  // fenced-code-chunks, etc.) picks it up without modification.
-  md.renderer.rules['colon_fence'] = (tokens, idx) => {
-    const token = tokens[idx];
-    const info = token.info.trim();
-    const parsedInfo = parseBlockInfo(info);
-    const normalizedInfo = normalizeBlockInfo(parsedInfo);
-    const content = escape(token.content);
-    const finalBreak =
-      idx < tokens.length && tokens[idx].type === 'list_item_close' ? '\n' : '';
-
-    return (
-      `<pre data-role="codeBlock"` +
-      ` data-info="${escape(info)}"` +
-      ` data-parsed-info="${escape(JSON.stringify(parsedInfo))}"` +
-      ` data-normalized-info="${escape(JSON.stringify(normalizedInfo))}"` +
-      ('data-source-line' in parsedInfo.attributes
-        ? ` data-source-line="${parsedInfo.attributes['data-source-line']}"`
-        : '') +
-      `>${content}</pre>${finalBreak}`
-    );
-  };
+  // Renderer: reuse the same rendering logic as backtick-fenced code blocks so
+  // the existing render-enhancer pipeline (fenced-diagrams, fenced-code-chunks,
+  // etc.) picks it up without modification.
+  md.renderer.rules['colon_fence'] = renderCodeBlockToken;
 };
 
 const COLON = 0x3a; // ':'

--- a/src/custom-markdown-it-features/colon-fenced-code-blocks.ts
+++ b/src/custom-markdown-it-features/colon-fenced-code-blocks.ts
@@ -1,0 +1,146 @@
+/**
+ * Adds support for colon-fenced code blocks (Azure DevOps / GitLab wiki style):
+ *
+ *   :::mermaid
+ *   graph TD
+ *     A --> B
+ *   :::
+ *
+ * The blocks are rendered identically to backtick-fenced code blocks, so all
+ * supported diagram types (mermaid, plantuml, wavedrom, etc.) and syntax
+ * highlighting work out of the box without any additional changes to the
+ * rendering pipeline.
+ */
+
+import { escape } from 'html-escaper';
+import MarkdownIt from 'markdown-it';
+import { normalizeBlockInfo, parseBlockInfo } from '../lib/block-info';
+
+export default (md: MarkdownIt) => {
+  // Block rule: parse :::type ... ::: fences
+  md.block.ruler.before('fence', 'colon_fence', colonFenceRule, {
+    alt: ['paragraph', 'reference', 'blockquote', 'list'],
+  });
+
+  // Renderer: produce the same <pre data-role="codeBlock"> output as
+  // code-fences.ts so the existing render-enhancer pipeline (fenced-diagrams,
+  // fenced-code-chunks, etc.) picks it up without modification.
+  md.renderer.rules['colon_fence'] = (tokens, idx) => {
+    const token = tokens[idx];
+    const info = token.info.trim();
+    const parsedInfo = parseBlockInfo(info);
+    const normalizedInfo = normalizeBlockInfo(parsedInfo);
+    const content = escape(token.content);
+    const finalBreak =
+      idx < tokens.length && tokens[idx].type === 'list_item_close' ? '\n' : '';
+
+    return (
+      `<pre data-role="codeBlock"` +
+      ` data-info="${escape(info)}"` +
+      ` data-parsed-info="${escape(JSON.stringify(parsedInfo))}"` +
+      ` data-normalized-info="${escape(JSON.stringify(normalizedInfo))}"` +
+      ('data-source-line' in parsedInfo.attributes
+        ? ` data-source-line="${parsedInfo.attributes['data-source-line']}"`
+        : '') +
+      `>${content}</pre>${finalBreak}`
+    );
+  };
+};
+
+const COLON = 0x3a; // ':'
+
+function colonFenceRule(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  state: any,
+  startLine: number,
+  endLine: number,
+  silent: boolean,
+): boolean {
+  // Indented 4+ spaces → treat as indented code block, not a fence
+  if (state.tShift[startLine] - state.blkIndent >= 4) return false;
+
+  let pos = state.bMarks[startLine] + state.tShift[startLine];
+  const max = state.eMarks[startLine];
+
+  // Need at least ":::x" (4 characters)
+  if (pos + 3 >= max) return false;
+
+  // Must start with :::
+  if (
+    state.src.charCodeAt(pos) !== COLON ||
+    state.src.charCodeAt(pos + 1) !== COLON ||
+    state.src.charCodeAt(pos + 2) !== COLON
+  ) {
+    return false;
+  }
+
+  // Count opening colons (minimum 3)
+  const markerStart = pos;
+  pos = state.skipChars(pos, COLON);
+  const markerLen = pos - markerStart;
+
+  // Rest of the opening line is the info string (e.g. "mermaid")
+  const info = state.src.slice(pos, max).trim();
+
+  // Reject lines with no info string so that a bare ":::" cannot open a fence
+  // (it is only ever a closing marker).
+  if (info.length === 0) return false;
+
+  // Validation mode: we found a valid opening marker
+  if (silent) return true;
+
+  // Search for the matching closing fence
+  let nextLine = startLine;
+  let haveEndMarker = false;
+
+  for (;;) {
+    nextLine++;
+    if (nextLine >= endLine) {
+      // Unclosed fence — auto-close at end of document
+      break;
+    }
+
+    let linePos = state.bMarks[nextLine] + state.tShift[nextLine];
+    const lineMax = state.eMarks[nextLine];
+
+    // Non-empty line with indentation less than the fence → stop
+    if (linePos < lineMax && state.sCount[nextLine] < state.blkIndent) break;
+
+    // Must start with a colon
+    if (state.src.charCodeAt(linePos) !== COLON) continue;
+
+    // Indented 4+ spaces → not a closing fence
+    if (state.sCount[nextLine] - state.blkIndent >= 4) continue;
+
+    const closingStart = linePos;
+    linePos = state.skipChars(linePos, COLON);
+
+    // Closing marker must be at least as long as the opening marker
+    if (linePos - closingStart < markerLen) continue;
+
+    // Closing line must be blank after the colons
+    if (state.src.slice(linePos, lineMax).trim().length > 0) continue;
+
+    haveEndMarker = true;
+    break;
+  }
+
+  // Emit the token
+  const token = state.push('colon_fence', 'code', 0);
+  token.info = info;
+  token.content = state.getLines(
+    startLine + 1,
+    nextLine,
+    state.blkIndent,
+    true,
+  );
+  token.markup = state.src.slice(
+    state.bMarks[startLine] + state.tShift[startLine],
+    state.bMarks[startLine] + state.tShift[startLine] + markerLen,
+  );
+  token.map = [startLine, nextLine + 1];
+  token.block = true;
+
+  state.line = nextLine + (haveEndMarker ? 1 : 0);
+  return true;
+}

--- a/src/markdown-engine/transformer.ts
+++ b/src/markdown-engine/transformer.ts
@@ -253,6 +253,7 @@ export async function transformMarkdown(
   inputString = inputString.replace(/\r\n/g, '\n');
 
   let lastOpeningCodeBlockFence: string | null = null;
+  let lastOpeningColonFence: string | null = null;
   let codeChunkOffset = 0;
   const slideConfigs: BlockAttributes[] = [];
   const JSAndCssFiles: string[] = [];
@@ -301,6 +302,58 @@ export async function transformMarkdown(
       // eslint-disable-next-line prefer-const
       let { line, blockquotePrefix, end } = getLine(i);
       outputString += blockquotePrefix;
+
+      // ========== Start: Colon Code Block ==========
+      // Handle :::lang ... ::: fences (Azure DevOps / GitLab wiki style).
+      // This section must run before the backtick-fence section so that
+      // backtick fences inside a colon block are treated as content.
+      const inColonCodeBlock = !!lastOpeningColonFence;
+      const colonFenceMatch = line.match(/^\s*(:{3,})(.*)/);
+      if (colonFenceMatch) {
+        const colonMarker = colonFenceMatch[1];
+        const afterColons = colonFenceMatch[2].trim();
+        if (!inColonCodeBlock && afterColons.length > 0) {
+          // Opening colon fence — inject data-source-line into the info string
+          // so the renderer can attach it to the <pre> element for preview sync.
+          if (canCreateAnchor()) {
+            const optStart = line.indexOf('{');
+            const optEnd = line.lastIndexOf('}');
+            if (optStart > 0 && optEnd > 0) {
+              const optString = line.substring(optStart + 1, optEnd);
+              line =
+                line.substring(0, optStart) +
+                ` {${optString} data-source-line="${lineNo + 1}"}`;
+            } else {
+              line = line.trimEnd() + ` {data-source-line="${lineNo + 1}"}`;
+            }
+          }
+          lastOpeningColonFence = colonMarker;
+          i = end + 1;
+          lineNo = lineNo + 1;
+          outputString = outputString + line + '\n';
+          continue;
+        } else if (
+          inColonCodeBlock &&
+          afterColons.length === 0 &&
+          colonMarker.length >= lastOpeningColonFence!.length
+        ) {
+          // Closing colon fence
+          lastOpeningColonFence = null;
+          i = end + 1;
+          lineNo = lineNo + 1;
+          outputString = outputString + line + '\n';
+          continue;
+        }
+      }
+
+      if (inColonCodeBlock) {
+        // Inside a colon block — pass through unchanged, like backtick blocks
+        i = end + 1;
+        lineNo = lineNo + 1;
+        outputString = outputString + line + '\n';
+        continue;
+      }
+      // ========== End: Colon Code Block ==========
 
       // ========== Start: Code Block ==========
       const inCodeBlock = !!lastOpeningCodeBlockFence;

--- a/src/notebook/index.ts
+++ b/src/notebook/index.ts
@@ -13,6 +13,7 @@ import { URI, Utils } from 'vscode-uri';
 import useMarkdownAdmonition from '../custom-markdown-it-features/admonition';
 import useMarkdownCallout from '../custom-markdown-it-features/callout';
 import useMarkdownItCodeFences from '../custom-markdown-it-features/code-fences';
+import useMarkdownItColonFencedCodeBlocks from '../custom-markdown-it-features/colon-fenced-code-blocks';
 import useMarkdownItCriticMarkup from '../custom-markdown-it-features/critic-markup';
 import useMarkdownItCurlyBracketAttributes from '../custom-markdown-it-features/curly-bracket-attributes';
 import useMarkdownItEmoji from '../custom-markdown-it-features/emoji';
@@ -152,6 +153,7 @@ export class Notebook {
     md.use(MarkdownItMark);
 
     useMarkdownItCodeFences(md);
+    useMarkdownItColonFencedCodeBlocks(md);
     useMarkdownItCurlyBracketAttributes(md);
     useMarkdownItCriticMarkup(md, this);
     useMarkdownItEmoji(md, this);


### PR DESCRIPTION
## Adds a new markdown-it block rule that recognises the colon-fence syntax used by Azure DevOps Wikis and GitLab:

  :::mermaid
  graph TD
    A --> B
  :::

The new `colon_fence` token is rendered with the same `<pre data-role="codeBlock">` output as the existing backtick-fence renderer, so the entire rendering pipeline (fenced-diagrams, mermaid, plantuml, wavedrom, etc.) works without any further changes.

Closes #408 