### PR TITLE
preview keeps jumping back to top when scrolling

### DIFF
--- a/src/webview/containers/preview.ts
+++ b/src/webview/containers/preview.ts
@@ -362,11 +362,17 @@ const PreviewContainer = createContainer(() => {
       return;
     }
 
-    buildScrollMap();
-
-    if (Date.now() < previewScrollDelay.current) {
-      return;
+    // When the user manually scrolls, cancel any programmatic scroll animation
+    // that might be running (e.g. scroll-to-cursor-line on file open).
+    // Without this, the animation keeps overriding the user's scroll position
+    // and the preview keeps snapping back to the top.
+    if (scrollTimeout.current) {
+      clearTimeout(scrollTimeout.current);
+      scrollTimeout.current = null;
     }
+    previewScrollDelay.current = 0;
+
+    buildScrollMap();
     previewSyncSource();
   }, [buildScrollMap, config.scrollSync, previewSyncSource]);
 


### PR DESCRIPTION
hey, not sure if anyone else has run into this but its been driving me crazy lol

## what's happening

whenever i open a markdown file and try to scroll down in the preview panel it just... snaps back to the top. like every time. doesnt matter how far i scroll, it fights me and pulls back up. makes the preview basically unusable if you're working on longer docs.

## why it happens

traced it down to the `scrollToRevealSourceLine` animation. when a file opens the cursor defaults to line 0, so the preview fires an animated scroll to position 0. the animation runs every 10ms and each tick does two things:

1. sets `previewScrollDelay` 500ms into the future -- so the scroll event listener sees the guard and bails out
2. calls `setWindowScrollTop` to push scroll position back toward 0

so the user is literally fighting the animation. and losing, because the animation reruns every 10ms for 120ms and then holds the delay for another 500ms after that. thats 620ms where your scroll gets overridden.

## the fix

in `scrollPreview` (the window scroll event handler), when a real user scroll comes in, cancel the pending animation timer and reset the delay guard to 0 before doing anything else. user scroll should always win over a programmatic sync animation.

```ts
// before
buildScrollMap();
if (Date.now() < previewScrollDelay.current) {
  return;
}
previewSyncSource();

// after
if (scrollTimeout.current) {
  clearTimeout(scrollTimeout.current);
  scrollTimeout.current = null;
}
previewScrollDelay.current = 0;
buildScrollMap();
previewSyncSource();
```

scroll sync still works fine -- when the cursor moves in the editor the preview still follows. its just that now if the user scrolls manually it actually takes effect instead of getting stomped on

tested locally with a few long markdown files, works as expected. happy to adjust anything if needed
