### PR TITLE
#417 - Adding zoom functionality to the webview

### DIFF
--- a/src/webview/components/ContextMenu.tsx
+++ b/src/webview/components/ContextMenu.tsx
@@ -4,6 +4,9 @@ import {
   mdiGraph,
   mdiImageOutline,
   mdiInformationOutline,
+  mdiMagnify,
+  mdiMagnifyMinus,
+  mdiMagnifyPlus,
   mdiMoonFull,
   mdiMoonNew,
   mdiOpenInNew,
@@ -35,6 +38,10 @@ export default function ContextMenu() {
     theme,
     isPresentationMode,
     enablePreviewZenMode,
+    zoomIn,
+    zoomOut,
+    resetZoom,
+    zoomLevel,
   } = PreviewContainer.useContainer();
 
   const handleItemClick = useCallback(
@@ -185,6 +192,18 @@ export default function ContextMenu() {
           postMessage('openExternalEditor', [sourceUri.current]);
           break;
         }
+        case 'zoom-in': {
+          zoomIn();
+          break;
+        }
+        case 'zoom-out': {
+          zoomOut();
+          break;
+        }
+        case 'reset-zoom': {
+          resetZoom();
+          break;
+        }
         case 'open-documentation': {
           postMessage('openDocumentation');
           break;
@@ -205,7 +224,15 @@ export default function ContextMenu() {
           break;
       }
     },
-    [postMessage, previewSyncSource, setShowImageHelper, sourceUri],
+    [
+      postMessage,
+      previewSyncSource,
+      resetZoom,
+      setShowImageHelper,
+      sourceUri,
+      zoomIn,
+      zoomOut,
+    ],
   );
 
   return (
@@ -374,6 +401,34 @@ export default function ContextMenu() {
             Sync Source
           </span>
         </Item>
+        <Separator></Separator>
+        <Submenu
+          label={
+            <span className="inline-flex flex-row items-center">
+              <Icon path={mdiMagnify} size={0.8} className="mr-2"></Icon>
+              Zoom ({Math.round(zoomLevel * 100)}%)
+            </span>
+          }
+        >
+          <Item id="zoom-in" onClick={handleItemClick}>
+            <span className="inline-flex flex-row items-center">
+              <Icon path={mdiMagnifyPlus} size={0.8} className="mr-2"></Icon>
+              Zoom In
+            </span>
+          </Item>
+          <Item id="zoom-out" onClick={handleItemClick}>
+            <span className="inline-flex flex-row items-center">
+              <Icon path={mdiMagnifyMinus} size={0.8} className="mr-2"></Icon>
+              Zoom Out
+            </span>
+          </Item>
+          <Item id="reset-zoom" onClick={handleItemClick}>
+            <span className="inline-flex flex-row items-center">
+              <Icon path={mdiMagnify} size={0.8} className="mr-2"></Icon>
+              Reset Zoom
+            </span>
+          </Item>
+        </Submenu>
         <Separator></Separator>
         <Submenu
           label={

--- a/src/webview/components/Footer.tsx
+++ b/src/webview/components/Footer.tsx
@@ -1,4 +1,10 @@
-import { Bars3Icon, LinkIcon, ShareIcon } from '@heroicons/react/24/outline';
+import {
+  Bars3Icon,
+  LinkIcon,
+  MagnifyingGlassMinusIcon,
+  MagnifyingGlassPlusIcon,
+  ShareIcon,
+} from '@heroicons/react/24/outline';
 import classNames from 'classnames';
 import React, { useEffect, useState } from 'react';
 import readingTime from 'reading-time/lib/reading-time';
@@ -18,6 +24,8 @@ export default function Footer() {
     enablePreviewZenMode,
     postMessage,
     sourceUri,
+    zoomIn,
+    zoomOut,
   } = PreviewContainer.useContainer();
   const [readingTimeEstimation, setReadingTimeEstimation] = useState<
     | {
@@ -81,6 +89,20 @@ export default function Footer() {
             }}
           >
             <LinkIcon className="w-5 h-5"></LinkIcon>
+          </div>
+          <div
+            className="p-1 cursor-pointer hover:text-primary w-5 h-5"
+            title="Zoom out"
+            onClick={() => zoomOut()}
+          >
+            <MagnifyingGlassMinusIcon className="w-5 h-5"></MagnifyingGlassMinusIcon>
+          </div>
+          <div
+            className="p-1 cursor-pointer hover:text-primary w-5 h-5"
+            title="Zoom in"
+            onClick={() => zoomIn()}
+          >
+            <MagnifyingGlassPlusIcon className="w-5 h-5"></MagnifyingGlassPlusIcon>
           </div>
           <div
             className="p-1 cursor-pointer hover:text-primary w-5 h-5"

--- a/src/webview/containers/preview.ts
+++ b/src/webview/containers/preview.ts
@@ -386,11 +386,11 @@ const PreviewContainer = createContainer(() => {
   }, [buildScrollMap, config.scrollSync, previewSyncSource]);
 
   const zoomIn = useCallback(() => {
-    setZoomLevel((x) => x + 0.1);
+    setZoomLevel((x) => Math.min(x + 0.1, 5));
   }, []);
 
   const zoomOut = useCallback(() => {
-    setZoomLevel((x) => x - 0.1);
+    setZoomLevel((x) => Math.max(x - 0.1, 0.2));
   }, []);
 
   const resetZoom = useCallback(() => {
@@ -1415,7 +1415,7 @@ const PreviewContainer = createContainer(() => {
         previewSyncSource();
       } else if (data.command === 'copy') {
         document.execCommand('copy');
-      } else if (data.command === 'zommIn') {
+      } else if (data.command === 'zoomIn' || data.command === 'zommIn') {
         zoomIn();
       } else if (data.command === 'zoomOut') {
         zoomOut();
@@ -1635,6 +1635,91 @@ const PreviewContainer = createContainer(() => {
   }, [isVSCode, postMessage, zoomLevel]);
 
   /**
+   * Apply zoom level to the document body and counter-zoom fixed elements
+   * so they remain at their original size.
+   */
+  useEffect(() => {
+    document.body.style.zoom = String(zoomLevel);
+
+    if (zoomLevel !== 1) {
+      const counterZoom = 1 / zoomLevel;
+      const els = document.querySelectorAll<HTMLElement>('.fixed, .contexify');
+      for (const el of els) {
+        // Skip nested .contexify (submenus) — they inherit the
+        // parent's counter-zoom automatically.
+        if (
+          el.classList.contains('contexify') &&
+          el.parentElement?.closest('.contexify')
+        ) {
+          el.style.zoom = '';
+          continue;
+        }
+        el.style.zoom = String(counterZoom);
+      }
+    } else {
+      const els = document.querySelectorAll<HTMLElement>('.fixed, .contexify');
+      for (const el of els) {
+        el.style.zoom = '';
+      }
+    }
+  }, [zoomLevel]);
+
+  /**
+   * Counter-zoom newly added fixed / context-menu elements via
+   * MutationObserver so late-rendered DOM stays consistent.
+   */
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      if (zoomLevel === 1) {
+        return;
+      }
+      const counterZoom = 1 / zoomLevel;
+      const els = document.querySelectorAll<HTMLElement>('.fixed, .contexify');
+      for (const el of els) {
+        if (
+          el.classList.contains('contexify') &&
+          el.parentElement?.closest('.contexify')
+        ) {
+          el.style.zoom = '';
+          continue;
+        }
+        el.style.zoom = String(counterZoom);
+      }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+    return () => {
+      observer.disconnect();
+    };
+  }, [zoomLevel]);
+
+  /**
+   * Ctrl+wheel (Cmd+wheel on macOS) zoom handler.
+   */
+  useEffect(() => {
+    const handler = (e: WheelEvent) => {
+      if (!(e.ctrlKey || e.metaKey)) {
+        return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      if (e.deltaY < 0) {
+        zoomIn();
+      } else {
+        zoomOut();
+      }
+    };
+    document.addEventListener('wheel', handler, {
+      passive: false,
+      capture: true,
+    });
+    return () => {
+      document.removeEventListener('wheel', handler, {
+        capture: true,
+      } as EventListenerOptions);
+    };
+  }, [zoomIn, zoomOut]);
+
+  /**
    * On load
    */
   useEffect(() => {
@@ -1767,7 +1852,10 @@ const PreviewContainer = createContainer(() => {
     sourceScheme,
     sourceUri,
     theme,
+    zoomIn,
     zoomLevel,
+    zoomOut,
+    resetZoom,
   };
 });
 


### PR DESCRIPTION
Feature request [#417](https://github.com/shd101wyy/crossnote/issues/417) — Ability to zoom markdown preview window

### Summary

Adds native zoom support to the markdown preview webview, allowing users to zoom in/out of the rendered preview content.

### Changes

**Zoom controls (3 methods):**

- **Ctrl+mouse wheel** (Cmd+wheel on macOS) — zoom in/out with scroll
- **Context menu** — right-click → Zoom submenu with Zoom In, Zoom Out, and Reset Zoom options (shows current zoom percentage)
- **Footer bar buttons** — magnifying glass +/- icons next to the menu icon
- **Message API** — the extension can send `zoomIn`, `zoomOut`, and `resetZoom` commands via `postMessage` for keybinding support

**Implementation details:**

- Zoom range bounded between 20% and 500%
- Counter-zoom applied to fixed-position elements (footer, topbar, context menu) so they remain at normal size
- MutationObserver watches for dynamically added DOM elements that need counter-zoom
- Zoom level persisted in React state via `PreviewContainer`

### Files changed

- preview.ts — zoom state, Ctrl+wheel handler, body zoom effect, counter-zoom for fixed elements, MutationObserver, message handler for `zoomIn`/`zoomOut`/`resetZoom`
- ContextMenu.tsx — zoom submenu with current zoom percentage
- Footer.tsx — zoom in/out icon buttons

### Screenshots
Added zoom icons
<img width="185" height="50" alt="image" src="https://github.com/user-attachments/assets/57926037-1e02-4338-8dd5-958677349928" />

Added context menu options
<img width="526" height="169" alt="image" src="https://github.com/user-attachments/assets/a3f2f2fc-aa79-4604-8d1a-98d22997d9e7" />
