### PR TITLE
Added code to inherit the VS Code theme for the context menu

### DIFF
--- a/src/notebook/types.ts
+++ b/src/notebook/types.ts
@@ -549,6 +549,18 @@ export interface NotebookConfig {
   isVSCode: boolean;
 
   /**
+   * Whether to use a native VS Code-style context menu in the preview.
+   *
+   * When enabled, the right-click context menu inherits VS Code's theme
+   * colors and font instead of using the preview theme's styling.
+   *
+   * Only takes effect when running inside VS Code.
+   *
+   * @default false
+   */
+  useVSCodeThemeForContextMenu: boolean;
+
+  /**
    * Whether to always show backlinks in preview.
    */
   alwaysShowBacklinksInPreview: boolean;
@@ -657,6 +669,7 @@ export function getDefaultNotebookConfig(): NotebookConfig {
     d2Sketch: false,
     isVSCode: false,
     alwaysShowBacklinksInPreview: false,
+    useVSCodeThemeForContextMenu: false,
   };
 }
 

--- a/src/webview/components/ContextMenu.tsx
+++ b/src/webview/components/ContextMenu.tsx
@@ -17,6 +17,7 @@ import classNames from 'classnames';
 import React, { useCallback } from 'react';
 import { Item, ItemParams, Menu, Separator, Submenu } from 'react-contexify';
 import 'react-contexify/ReactContexify.css';
+import './context-menu-vscode.css';
 import PreviewContainer from '../containers/preview';
 
 export default function ContextMenu() {
@@ -208,9 +209,19 @@ export default function ContextMenu() {
     [postMessage, previewSyncSource, setShowImageHelper, sourceUri],
   );
 
+  const useNativeMenu =
+    (isVSCode || isVSCodeWebExtension) &&
+    config.useVSCodeThemeForContextMenu !== false;
+
   return (
     <div data-theme={theme} className="select-none">
-      <Menu id={contextMenuId} theme={theme === 'dark' ? 'dark' : undefined}>
+      <Menu
+        id={contextMenuId}
+        theme={
+          useNativeMenu ? undefined : theme === 'dark' ? 'dark' : undefined
+        }
+        className={useNativeMenu ? 'native-vscode-menu' : undefined}
+      >
         <Item id="open-graph-view" onClick={handleItemClick}>
           <span className="inline-flex flex-row items-center">
             <Icon path={mdiGraph} size={0.8} className="mr-2"></Icon>

--- a/src/webview/components/context-menu-vscode.css
+++ b/src/webview/components/context-menu-vscode.css
@@ -1,0 +1,62 @@
+/*
+ * VS Code-native context menu overrides for react-contexify.
+ *
+ * These rules only apply when the .native-vscode-menu class is present on the
+ * Menu component (controlled by the useVSCodeThemeForContextMenu config option) AND
+ * the preview runs inside a VS Code webview (body has vscode-* classes and
+ * --vscode-* CSS custom properties).
+ */
+
+body:is(
+    .vscode-dark,
+    .vscode-light,
+    .vscode-high-contrast,
+    .vscode-high-contrast-light
+  )
+  .native-vscode-menu.contexify {
+  --contexify-menu-minWidth: 160px;
+  --contexify-itemContent-padding: 4px 8px;
+  --contexify-separator-margin: 3px;
+  --contexify-menu-bgColor: var(--vscode-menu-background);
+  --contexify-separator-color: var(--vscode-menu-separatorBackground);
+  --contexify-item-color: var(--vscode-menu-foreground);
+  --contexify-activeItem-color: var(--vscode-menu-selectionForeground);
+  --contexify-activeItem-bgColor: var(--vscode-menu-selectionBackground);
+  --contexify-rightSlot-color: var(--vscode-menu-foreground);
+  --contexify-arrow-color: var(--vscode-menu-foreground);
+  color: var(--vscode-menu-foreground);
+  font-size: var(--vscode-font-size);
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe WPC', 'Segoe UI', 'Ubuntu',
+    'Droid Sans', sans-serif;
+  line-height: normal;
+  border: 1px solid var(--vscode-menu-border, transparent);
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.16);
+}
+
+/*
+ * Override react-contexify built-in theme classes (.contexify_theme-dark,
+ * .contexify_theme-light) which set variables directly on the element and
+ * would otherwise win over the above rules.
+ */
+body:is(
+    .vscode-dark,
+    .vscode-light,
+    .vscode-high-contrast,
+    .vscode-high-contrast-light
+  )
+  .native-vscode-menu.contexify.contexify_theme-dark,
+body:is(
+    .vscode-dark,
+    .vscode-light,
+    .vscode-high-contrast,
+    .vscode-high-contrast-light
+  )
+  .native-vscode-menu.contexify.contexify_theme-light {
+  --contexify-menu-bgColor: var(--vscode-menu-background);
+  --contexify-separator-color: var(--vscode-menu-separatorBackground);
+  --contexify-item-color: var(--vscode-menu-foreground);
+  --contexify-activeItem-color: var(--vscode-menu-selectionForeground);
+  --contexify-activeItem-bgColor: var(--vscode-menu-selectionBackground);
+}


### PR DESCRIPTION
Successor PR: https://github.com/shd101wyy/vscode-markdown-preview-enhanced/pull/2274

Adds an opt-in `useVSCodeThemeForContextMenu` config option that makes the preview's right-click context menu inherit VS Code's theme colors and fonts instead of using react-contexify's default styling.

**Changes:**
- **types.ts** — Added `useVSCodeThemeForContextMenu: boolean` (default `false`) to `NotebookConfig` and its defaults.
- **ContextMenu.tsx** — When the setting is enabled and running in VS Code, the `<Menu>` component gets a `native-vscode-menu` CSS class and skips the react-contexify theme prop, allowing the CSS overrides to take effect.
- **context-menu-vscode.css** *(new)* — Maps `--vscode-menu-*` CSS custom properties (injected by VS Code webviews) to react-contexify's `--contexify-*` variables, plus sets font, border, and box-shadow to match VS Code's native menu appearance. Rules are scoped to `.native-vscode-menu.contexify` under VS Code body classes, with specificity overrides for the built-in `.contexify_theme-dark`/`.contexify_theme-light` classes.

The context menu currently always looks like this
<img width="275" height="638" alt="Contexify theme" src="https://github.com/user-attachments/assets/d1a24436-9ef8-42f0-a550-8445130b5de6" />

With the new option we can have a menu that looks like it is part of VS Code
<img width="212" height="463" alt="VS Code theme" src="https://github.com/user-attachments/assets/daa5fd2c-e3af-4df1-b623-a756c5d076ae" />

Even when you change the theme for the markdown preview, it keeps inheriting the VS Code theme
<img width="967" height="642" alt="VS Code theme" src="https://github.com/user-attachments/assets/d36663fe-0e7e-4160-a8c7-e25a17a0838b" />

