### PR TITLE
fix: wikilink preview respects wikiLinkResolution + feat: Graph View link direction filter

### DIFF
--- a/src/custom-markdown-it-features/wikilink.ts
+++ b/src/custom-markdown-it-features/wikilink.ts
@@ -3,6 +3,7 @@
  * [[...]]
  */
 
+import * as path from 'path';
 import MarkdownIt from 'markdown-it';
 import { Notebook } from '../notebook';
 
@@ -71,7 +72,22 @@ export default (md: MarkdownIt, notebook: Notebook) => {
       filePart,
       notebook.currentRenderFilePath,
     );
-    const resolvedLink = resolvedPath + fragment;
+
+    // resolveWikilink returns a notebook-root-relative path (e.g. 'test.md',
+    // 'sub\dir\note.md' on Windows).  The render-enhancer resolved-image-paths.ts
+    // will later call resolveFilePath(href, …, currentFileDir), which treats
+    // any bare relative path as relative to the CURRENT FILE's directory — not
+    // the notebook root.  We must therefore convert notebook-relative →
+    // file-directory-relative so that the final absolute path is correct.
+    const currentFileDir = path
+      .dirname(notebook.currentRenderFilePath)
+      .replace(/\\/g, '/');
+    const resolvedNorm = resolvedPath.replace(/\\/g, '/');
+    // path.posix.relative('.', 'test.md') === 'test.md'  (root-level file, viewed from root)
+    // path.posix.relative('sub/dir', 'test.md') === '../../test.md'  (cross-directory)
+    const fileRelativeHref = path.posix.relative(currentFileDir, resolvedNorm);
+
+    const resolvedLink = fileRelativeHref + fragment;
 
     // When the user provided an alias (`[[…|Display]]`) processWikilink
     // already gave us the alias as `text`.  When they didn't, `text`

--- a/src/custom-markdown-it-features/wikilink.ts
+++ b/src/custom-markdown-it-features/wikilink.ts
@@ -54,7 +54,24 @@ export default (md: MarkdownIt, notebook: Notebook) => {
       return '';
     }
 
-    const { text, link } = notebook.processWikilink(content);
+    const { text, link, hash, blockRef } = notebook.processWikilink(content);
+
+    // processWikilink appends hash and blockRef to the link string.
+    // Strip them to get the pure file path for resolveWikilink().
+    const fragment = (hash || '') + (blockRef || '');
+    const filePart = fragment
+      ? link.slice(0, link.length - fragment.length)
+      : link;
+
+    // Resolve using the configured wikiLinkResolution mode so that
+    // wikiLinkResolution:'shortest' (and 'absolute') actually affect
+    // the preview <a href>.  (Previously only processWikilink() was
+    // called, which never does path resolution.)
+    const resolvedPath = notebook.resolveWikilink(
+      filePart,
+      notebook.currentRenderFilePath,
+    );
+    const resolvedLink = resolvedPath + fragment;
 
     // When the user provided an alias (`[[…|Display]]`) processWikilink
     // already gave us the alias as `text`.  When they didn't, `text`
@@ -64,7 +81,7 @@ export default (md: MarkdownIt, notebook: Notebook) => {
       ? text
       : formatWikilinkDisplay(text);
 
-    return `<a href="${md.utils.escapeHtml(link)}">${md.utils.escapeHtml(
+    return `<a href="${md.utils.escapeHtml(resolvedLink)}">${md.utils.escapeHtml(
       displayText,
     )}</a>`;
   };

--- a/src/markdown-engine/index.ts
+++ b/src/markdown-engine/index.ts
@@ -2843,6 +2843,16 @@ sidebarTOCBtn.addEventListener('click', function(event) {
         this.notebook.notebookPath.fsPath,
         this.filePath,
       );
+      // For shortest mode, ensure the note index is populated so that
+      // resolveWikilink() can find targets across the whole notebook.
+      // relative and absolute modes compute paths from the link string
+      // directly and never access this.notes.
+      if (this.notebook.config.wikiLinkResolution === 'shortest') {
+        await this.notebook.refreshNotesIfNotLoaded({
+          dir: '.',
+          includeSubdirectories: true,
+        });
+      }
       html = this.notebook.renderMarkdown(outputString, {
         isForPreview: options.isForPreview,
       });

--- a/src/markdown-engine/index.ts
+++ b/src/markdown-engine/index.ts
@@ -2836,6 +2836,13 @@ sidebarTOCBtn.addEventListener('click', function(event) {
       }
     } else {
       // markdown-it or markdown_yo
+      // Set context so the wikilink renderer can call resolveWikilink()
+      // with the correct current-note path, making wikiLinkResolution
+      // actually affect the preview <a href>.
+      this.notebook.currentRenderFilePath = path.relative(
+        this.notebook.notebookPath.fsPath,
+        this.filePath,
+      );
       html = this.notebook.renderMarkdown(outputString, {
         isForPreview: options.isForPreview,
       });

--- a/src/notebook/index.ts
+++ b/src/notebook/index.ts
@@ -1285,7 +1285,7 @@ export class Notebook {
   }
 
   /*
-  // NOTE: This function is hidden for now.  
+  // NOTE: This function is hidden for now.
   public async writeNote(
     filePath: string,
     markdown: string,
@@ -1537,18 +1537,28 @@ export class Notebook {
         return candidates[0];
       }
       if (candidates.length > 1) {
+        // Normalize to forward slashes for cross-platform depth comparison
+        // and same-directory preference (path.sep is '\' on Windows).
+        const normalize = (p: string) => p.replace(/\\/g, '/');
         candidates.sort(
           (a, b) =>
-            a.split(path.sep).length - b.split(path.sep).length ||
+            normalize(a).split('/').length - normalize(b).split('/').length ||
             a.localeCompare(b),
         );
-        const best = candidates[0];
-        const bestDepth = best.split(path.sep).length;
+        const bestDepth = normalize(candidates[0]).split('/').length;
         const shortest = candidates.filter(
-          (c) => c.split(path.sep).length === bestDepth,
+          (c) => normalize(c).split('/').length === bestDepth,
         );
-        const noteDir = path.dirname(currentNoteFilePath) + path.sep;
-        const inDir = shortest.find((c) => c.startsWith(noteDir));
+        const normalizedDir = normalize(path.dirname(currentNoteFilePath));
+        const inDir = shortest.find((c) => {
+          const nc = normalize(c);
+          // When the current note is at the notebook root, prefer root-level
+          // candidates (no '/' in their path).
+          if (normalizedDir === '.') {
+            return !nc.includes('/');
+          }
+          return nc.startsWith(normalizedDir + '/');
+        });
         return inDir || shortest[0];
       }
       // No match found — fall through to relative resolution.

--- a/src/notebook/index.ts
+++ b/src/notebook/index.ts
@@ -116,6 +116,13 @@ export class Notebook {
 
   public notes: Notes = {};
   public hasLoadedNotes: boolean = false;
+  /**
+   * The notebook-relative path of the note currently being rendered.
+   * Set by MarkdownEngine.parseMD() before calling renderMarkdown().
+   * Used by the wikilink renderer to call resolveWikilink() with the
+   * correct context.
+   */
+  public currentRenderFilePath: string = '';
   public referenceMap: ReferenceMap = new ReferenceMap();
   /**
    * Global `#tag` index.  Independent of the file system: tags are
@@ -1510,11 +1517,22 @@ export class Notebook {
       );
     }
 
-    if (mode === 'shortest' && !link.includes('/')) {
-      const basename = path.basename(link);
-      const candidates = Object.keys(this.notes).filter(
-        (notePath) => path.basename(notePath) === basename,
-      );
+    if (mode === 'shortest') {
+      // Normalize to forward slashes for cross-platform comparison.
+      const normalizedLink = link.replace(/\\/g, '/');
+
+      // Suffix-matching: bare filename (no '/') matches any note with that
+      // basename; a partial path (has '/') matches notes whose path ends
+      // with that sub-path.  This lets [[summary/report]] resolve to any
+      // note whose path ends with "summary/report.md", disambiguating
+      // same-named files in different directories.
+      const candidates = Object.keys(this.notes).filter((notePath) => {
+        const normalizedNote = notePath.replace(/\\/g, '/');
+        return (
+          normalizedNote === normalizedLink ||
+          normalizedNote.endsWith('/' + normalizedLink)
+        );
+      });
       if (candidates.length === 1) {
         return candidates[0];
       }
@@ -1533,15 +1551,16 @@ export class Notebook {
         const inDir = shortest.find((c) => c.startsWith(noteDir));
         return inDir || shortest[0];
       }
+      // No match found — fall through to relative resolution.
     }
 
     // Relative to current note's directory (default).
-    return path.relative(
-      this.notebookPath.fsPath,
-      path.join(
-        path.dirname(path.join(this.notebookPath.fsPath, currentNoteFilePath)),
-        link,
-      ),
-    );
+    // Guard: when currentNoteFilePath is '' (not set by MarkdownEngine),
+    // path.dirname(notebookPath) would escape above the notebook root.
+    // Treat '' as a virtual file at the notebook root instead.
+    const noteDir = currentNoteFilePath
+      ? path.dirname(path.join(this.notebookPath.fsPath, currentNoteFilePath))
+      : this.notebookPath.fsPath;
+    return path.relative(this.notebookPath.fsPath, path.join(noteDir, link));
   }
 }

--- a/src/webview/components/GraphViewComponent.tsx
+++ b/src/webview/components/GraphViewComponent.tsx
@@ -37,6 +37,7 @@ type D3Node = SimulationNodeDatum & GraphViewNode;
 type D3Link = SimulationLinkDatum<D3Node>;
 
 type ViewMode = 'global' | 'local';
+type LinkDirection = 'all' | 'frontlink' | 'backlink';
 
 const MIN_NODE_RADIUS = 5;
 const MAX_NODE_RADIUS = 14;
@@ -118,6 +119,7 @@ export default function GraphViewComponent() {
   const [viewMode, setViewMode] = useState<ViewMode>('global');
   const [localDepth, setLocalDepth] = useState(1);
   const [colorByFolder, setColorByFolder] = useState(false);
+  const [linkDirection, setLinkDirection] = useState<LinkDirection>('all');
 
   // Keep ref in sync so simulation callbacks can read the latest active path
   // without needing to be in the dependency array
@@ -268,8 +270,8 @@ export default function GraphViewComponent() {
   const visibleData = useMemo(() => {
     if (!graphData) return { nodes: [], links: [] };
     if (viewMode === 'local' && activeFilePath) {
-      const nodes = graphData.nodes.filter((n) => localNodeIds.has(n.id));
-      const links = graphData.links.filter((l) => {
+      // First, filter links based on localNodeIds
+      let links = graphData.links.filter((l) => {
         const src =
           typeof l.source === 'string'
             ? l.source
@@ -280,10 +282,48 @@ export default function GraphViewComponent() {
             : (l.target as GraphViewNode).id;
         return localNodeIds.has(src) && localNodeIds.has(tgt);
       });
+
+      // Apply link direction filter in LOCAL mode
+      if (linkDirection !== 'all') {
+        if (linkDirection === 'frontlink') {
+          links = links.filter((l) => {
+            const src =
+              typeof l.source === 'string'
+                ? l.source
+                : (l.source as GraphViewNode).id;
+            return src === activeFilePath;
+          });
+        } else if (linkDirection === 'backlink') {
+          links = links.filter((l) => {
+            const tgt =
+              typeof l.target === 'string'
+                ? l.target
+                : (l.target as GraphViewNode).id;
+            return tgt === activeFilePath;
+          });
+        }
+      }
+
+      // Derive nodes from filtered links, always including activeFilePath
+      const visibleNodeIds = new Set<string>([activeFilePath]);
+      for (const l of links) {
+        const src =
+          typeof l.source === 'string'
+            ? l.source
+            : (l.source as GraphViewNode).id;
+        const tgt =
+          typeof l.target === 'string'
+            ? l.target
+            : (l.target as GraphViewNode).id;
+        visibleNodeIds.add(src);
+        visibleNodeIds.add(tgt);
+      }
+      const nodes = graphData.nodes.filter((n) => visibleNodeIds.has(n.id));
+
       return { nodes, links };
     }
     return { nodes: graphData.nodes, links: graphData.links };
-  }, [graphData, viewMode, activeFilePath, localNodeIds]);
+  }, [graphData, viewMode, activeFilePath, localNodeIds, linkDirection]);
 
   // Search matched node ids
   const searchMatches = useMemo(() => {
@@ -725,6 +765,33 @@ export default function GraphViewComponent() {
             <span className="w-3 text-center font-mono text-base-content/80">
               {localDepth}
             </span>
+          </div>
+        )}
+
+        {/* Link direction filter — only visible in local mode */}
+        {viewMode === 'local' && (
+          <div className="join shrink-0">
+            <button
+              className={`join-item btn btn-xs ${linkDirection === 'all' ? 'btn-primary' : 'btn-ghost'}`}
+              onClick={() => setLinkDirection('all')}
+              title="Show all links"
+            >
+              All
+            </button>
+            <button
+              className={`join-item btn btn-xs ${linkDirection === 'frontlink' ? 'btn-primary' : 'btn-ghost'}`}
+              onClick={() => setLinkDirection('frontlink')}
+              title="Links from current file to others"
+            >
+              Front
+            </button>
+            <button
+              className={`join-item btn btn-xs ${linkDirection === 'backlink' ? 'btn-primary' : 'btn-ghost'}`}
+              onClick={() => setLinkDirection('backlink')}
+              title="Links from other files to current"
+            >
+              Back
+            </button>
           </div>
         )}
 

--- a/src/webview/components/GraphViewComponent.tsx
+++ b/src/webview/components/GraphViewComponent.tsx
@@ -37,7 +37,7 @@ type D3Node = SimulationNodeDatum & GraphViewNode;
 type D3Link = SimulationLinkDatum<D3Node>;
 
 type ViewMode = 'global' | 'local';
-type LinkDirection = 'all' | 'frontlink' | 'backlink';
+type LinkDirection = 'all' | 'direct' | 'frontlink' | 'backlink';
 
 const MIN_NODE_RADIUS = 5;
 const MAX_NODE_RADIUS = 14;
@@ -285,7 +285,19 @@ export default function GraphViewComponent() {
 
       // Apply link direction filter in LOCAL mode
       if (linkDirection !== 'all') {
-        if (linkDirection === 'frontlink') {
+        if (linkDirection === 'direct') {
+          links = links.filter((l) => {
+            const src =
+              typeof l.source === 'string'
+                ? l.source
+                : (l.source as GraphViewNode).id;
+            const tgt =
+              typeof l.target === 'string'
+                ? l.target
+                : (l.target as GraphViewNode).id;
+            return src === activeFilePath || tgt === activeFilePath;
+          });
+        } else if (linkDirection === 'frontlink') {
           links = links.filter((l) => {
             const src =
               typeof l.source === 'string'
@@ -774,9 +786,16 @@ export default function GraphViewComponent() {
             <button
               className={`join-item btn btn-xs ${linkDirection === 'all' ? 'btn-primary' : 'btn-ghost'}`}
               onClick={() => setLinkDirection('all')}
-              title="Show all links"
+              title="Show all links within depth range"
             >
               All
+            </button>
+            <button
+              className={`join-item btn btn-xs ${linkDirection === 'direct' ? 'btn-primary' : 'btn-ghost'}`}
+              onClick={() => setLinkDirection('direct')}
+              title="Links directly connected to current file"
+            >
+              Direct
             </button>
             <button
               className={`join-item btn btn-xs ${linkDirection === 'frontlink' ? 'btn-primary' : 'btn-ghost'}`}

--- a/test/wikilink-resolve.test.ts
+++ b/test/wikilink-resolve.test.ts
@@ -1,0 +1,166 @@
+﻿/**
+ * Tests for Notebook.resolveWikilink():
+ *  - Bug fix: empty currentNoteFilePath no longer escapes above the notebook root
+ *  - Enhancement: 'shortest' mode now uses suffix-matching so partial paths
+ *    like [[summary/report]] resolve to notes ending with that sub-path
+ */
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import { Notebook } from '../src/notebook';
+
+describe('resolveWikilink', () => {
+  let notebookPath: string;
+
+  beforeEach(async () => {
+    notebookPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'crossnote-resolve-'),
+    );
+  });
+
+  afterEach(async () => {
+    await fs.rm(notebookPath, { recursive: true, force: true });
+  });
+
+  async function writeNote(relPath: string, body: string = '') {
+    const abs = path.join(notebookPath, relPath);
+    await fs.mkdir(path.dirname(abs), { recursive: true });
+    await fs.writeFile(abs, body);
+  }
+
+  async function loaded(): Promise<Notebook> {
+    const nb = await Notebook.init({
+      notebookPath,
+      config: { markdownParser: 'markdown-it' },
+    });
+    await nb.refreshNotes({ dir: '.', includeSubdirectories: true });
+    return nb;
+  }
+
+  // ──────────────────────────────────────────────────────────────
+  // Bug fix: empty currentNoteFilePath must not escape to parent dir
+  // ──────────────────────────────────────────────────────────────
+
+  it('relative mode with empty currentNoteFilePath resolves to notebook root', async () => {
+    await writeNote('README.md');
+    const nb = await loaded();
+
+    // Default mode is 'relative'.  With empty currentNoteFilePath the
+    // old code produced '..\\README.md'; after the fix it should be
+    // just 'README.md'.
+    const result = nb.resolveWikilink('README.md', '');
+    expect(result).toBe('README.md');
+  });
+
+  it('relative mode with a sub-dir note resolves relative to that dir', async () => {
+    await writeNote('docs/guide.md');
+    await writeNote('README.md');
+    const nb = await loaded();
+
+    const result = nb.resolveWikilink('README.md', 'docs/guide.md');
+    // The resolved path is relative to the notebook root.
+    // 'docs/guide.md' → dir is 'docs' → path.join(docs, README.md)
+    // but README.md lives at root, so relative path goes up one.
+    expect(result).toBe(path.join('docs', 'README.md'));
+  });
+
+  // ──────────────────────────────────────────────────────────────
+  // 'shortest' mode — bare filename (backward compat)
+  // ──────────────────────────────────────────────────────────────
+
+  it('shortest mode: bare filename resolves to the unique matching note', async () => {
+    await writeNote('deep/nested/report.md');
+    const nb = await loaded();
+    nb.config.wikiLinkResolution = 'shortest';
+
+    const result = nb.resolveWikilink('report.md', 'other/note.md');
+    expect(result).toBe(path.join('deep', 'nested', 'report.md'));
+  });
+
+  it('shortest mode: bare filename with multiple matches picks shortest path', async () => {
+    await writeNote('a/report.md');
+    await writeNote('a/b/c/report.md');
+    const nb = await loaded();
+    nb.config.wikiLinkResolution = 'shortest';
+
+    const result = nb.resolveWikilink('report.md', 'other/note.md');
+    // 'a/report.md' has fewer path segments than 'a/b/c/report.md'
+    expect(result).toBe(path.join('a', 'report.md'));
+  });
+
+  it('shortest mode: bare filename with ties prefers same-dir note', async () => {
+    await writeNote('x/report.md');
+    await writeNote('y/report.md');
+    const nb = await loaded();
+    nb.config.wikiLinkResolution = 'shortest';
+
+    // current note is inside 'x/', so 'x/report.md' should win
+    const result = nb.resolveWikilink('report.md', 'x/current.md');
+    expect(result).toBe(path.join('x', 'report.md'));
+  });
+
+  it('shortest mode: no match falls back to relative resolution', async () => {
+    await writeNote('README.md');
+    const nb = await loaded();
+    nb.config.wikiLinkResolution = 'shortest';
+
+    // 'nonexistent.md' is not in the notes index → relative fallback
+    const result = nb.resolveWikilink('nonexistent.md', 'docs/note.md');
+    expect(result).toBe(path.join('docs', 'nonexistent.md'));
+  });
+
+  // ──────────────────────────────────────────────────────────────
+  // 'shortest' mode — suffix-matching (NEW enhancement)
+  // ──────────────────────────────────────────────────────────────
+
+  it('shortest mode: partial path [[summary/report]] matches by suffix', async () => {
+    await writeNote('projectA/summary/report.md');
+    await writeNote('projectB/other.md');
+    const nb = await loaded();
+    nb.config.wikiLinkResolution = 'shortest';
+
+    const result = nb.resolveWikilink('summary/report.md', 'projectB/other.md');
+    expect(result).toBe(path.join('projectA', 'summary', 'report.md'));
+  });
+
+  it('shortest mode: exact notebook-relative path resolves unambiguously', async () => {
+    await writeNote('projectA/summary/report.md');
+    await writeNote('projectB/summary/report.md');
+    const nb = await loaded();
+    nb.config.wikiLinkResolution = 'shortest';
+
+    // Full path — only one match
+    const resultA = nb.resolveWikilink(
+      'projectA/summary/report.md',
+      'other/note.md',
+    );
+    expect(resultA).toBe(path.join('projectA', 'summary', 'report.md'));
+
+    const resultB = nb.resolveWikilink(
+      'projectB/summary/report.md',
+      'other/note.md',
+    );
+    expect(resultB).toBe(path.join('projectB', 'summary', 'report.md'));
+  });
+
+  it('shortest mode: ambiguous partial path picks shortest candidate', async () => {
+    await writeNote('projectA/summary/report.md');
+    await writeNote('projectB/summary/report.md');
+    const nb = await loaded();
+    nb.config.wikiLinkResolution = 'shortest';
+
+    // Both match suffix 'summary/report.md'.  They have the same depth
+    // (3 segments each), so tiebreak is lexicographic → 'projectA' wins.
+    const result = nb.resolveWikilink('summary/report.md', 'other/note.md');
+    expect(result).toBe(path.join('projectA', 'summary', 'report.md'));
+  });
+
+  it('shortest mode: partial path no match falls back to relative resolution', async () => {
+    await writeNote('README.md');
+    const nb = await loaded();
+    nb.config.wikiLinkResolution = 'shortest';
+
+    const result = nb.resolveWikilink('ghost/nonexistent.md', 'docs/note.md');
+    expect(result).toBe(path.join('docs', 'ghost', 'nonexistent.md'));
+  });
+});


### PR DESCRIPTION
## Summary

Closes #424

This PR delivers a series of correctness fixes for `[[wikilink]]` resolution, primarily in **`shortest` mode** and in the **HTML preview rendering path**.  The three commits build on top of each other.

---

### Commit 1 — Preview `<a href>` now calls `resolveWikilink()` (original PR #434 content)

**Root cause:** The markdown-it wikilink renderer called `processWikilink()` which only handles alias, case normalisation, and extension stripping. It never called `resolveWikilink()`, so the `wikiLinkResolution` setting (`shortest` / `relative` / `absolute`) had no effect on the `href` attribute in the HTML preview. Every link resolved relative to the current file directory regardless of config.

**Fix (3 files):**

| File | Change |
|------|--------|
| `src/notebook/index.ts` | Add `currentRenderFilePath: string` field to `Notebook` class |
| `src/markdown-engine/index.ts` | Set `notebook.currentRenderFilePath` (relative to notebook root) before calling `renderMarkdown()` inside `parseMD()` |
| `src/custom-markdown-it-features/wikilink.ts` | Renderer now calls `resolveWikilink(filePart, notebook.currentRenderFilePath)`, re-appends stripped `#hash`/`^blockRef`, and uses the result as the `href` |

Also included in this commit: **suffix-matching in `shortest` mode** and **latent empty-path bug fix** (see below).

---

### Commit 2 — Ensure note index is populated + Windows path separator fix

**Problem A — empty index on first render:**
`shortest` mode calls `this.notes` (the in-memory note index) to find targets.  The index is only populated when the user explicitly opens Backlinks or Graph View.  On first preview render the index was empty, so every `[[link]]` fell back to relative resolution and created wrong stub files.

**Fix:** `parseMD` now calls `refreshNotesIfNotLoaded({ dir: '.', includeSubdirectories: true })` before `renderMarkdown()` when `wikiLinkResolution === 'shortest'`.  The call is guarded by an internal Mutex so concurrent renders are safe.  `relative` and `absolute` modes are unaffected.

**Problem B — Windows path separator in tie-breaking:**
`resolveWikilink`'s tie-breaking logic used `path.sep` (which is `'\\'` on Windows) to split candidate paths and to build the `startsWith` prefix.  On Windows the counts were always 1 (no separator found), so the depth sort was a no-op and same-directory preference never fired.

**Fix:** Introduce a `normalize = (p) => p.replace(/\\/g, '/')` helper and use it for all depth counts and prefix checks.  The code is now cross-platform.

---

### Commit 3 — Convert notebook-relative href to file-directory-relative

**Root cause (the trickiest bug):**
`resolveWikilink()` returns a **notebook-root-relative** path (e.g. `test.md`, `sub\dir\note.md`).  This was placed directly into `<a href="...">`, but the render enhancer `resolved-image-paths.ts` later calls:

```ts
resolveFilePath(href, useRelativeFilePath, fileDirectoryPath)
// where fileDirectoryPath = absolute path of the CURRENT FILE's directory
```

So a notebook-relative `href="test.md"` resolved as if it were in the *current file's directory*:

```
// current file: test2/2/2.md  →  [[test]]  →  resolveWikilink returns "test.md"
resolveFilePath("test.md", false, "C:\…\test2\2\")
= path.resolve("C:\…\test2\2\", "test.md")
= C:\…\test2\2\test.md   ✗  (creates a wrong stub file)
```

**Fix:** After `resolveWikilink()` returns a notebook-relative path, convert it to a path relative to the *current file's directory* using `path.posix.relative`:

```ts
const currentFileDir = path.dirname(notebook.currentRenderFilePath).replace(/\\/g, '/');
const resolvedNorm   = resolvedPath.replace(/\\/g, '/');
const fileRelativeHref = path.posix.relative(currentFileDir, resolvedNorm);
// href = fileRelativeHref + fragment
```

**Example:**

| Current file | Link | `resolveWikilink` returns | `href` inserted | Final resolved path |
|---|---|---|---|---|
| `test2/2/2.md` | `[[test]]` | `test.md` | `../../test.md` | `C:\…\test.md` ✅ |
| `test2/2/2.md` | `[[test2]]` | `test2/1/test2.md` | `../1/test2.md` | `C:\…\test2\1\test2.md` ✅ |
| `test.md` (root) | `[[testaaa]]` | `testaaa/testaaa.md` | `testaaa/testaaa.md` | `C:\…\testaaa\testaaa.md` ✅ |

Also adds the missing `import * as path from 'path'` to `wikilink.ts`.

---

### Enhancement: Suffix-Matching in `shortest` Mode (part of commit 1)

**Problem:** The previous `shortest` mode checked `!link.includes('/')` before searching note names, so `[[summary/report]]` always fell back to relative resolution even when the user intended it to disambiguate among notes in different directories.

**Fix:** Drop the `!link.includes('/')` guard and replace basename equality with suffix-matching (`notePath.endsWith('/' + link)`). Bare filenames continue to work as before (backward compatible).

---

### Latent Bug Fix: `resolveWikilink` with empty `currentNoteFilePath` (part of commit 1)

When `currentNoteFilePath` is `''` (e.g. when `renderMarkdown()` is called directly in unit tests without setting the field), `path.dirname(path.join(notebookPath, ''))` returns the *parent* of the notebook directory, causing links to escape the notebook root. The fix treats `''` as a virtual note located at the notebook root.

---

### Companion PR — `vscode-markdown-preview-enhanced`

The `shortest` mode fix for **Ctrl+Click** navigation (editor `DocumentLinkProvider`) lives in the MPE extension, not in crossnote.  A companion PR has been filed:

> **shd101wyy/vscode-markdown-preview-enhanced#2301** — fix: ensure note index is built before resolveWikilink for shortest mode (Ctrl+Click)

The change is a single guard in `resolveWikilinkUri` in `src/wikilink-document-link-provider.ts`:

```ts
if (notebook.config.wikiLinkResolution === 'shortest') {
  await notebook.refreshNotesIfNotLoaded({ dir: '.', includeSubdirectories: true });
}
```

Without it, the first Ctrl+Click on a `[[link]]` in shortest mode also ran against an empty index and navigated to / created a file in the current directory.

---

### Tests

Added `test/wikilink-resolve.test.ts` with **10 new unit tests**:

- `relative mode with empty currentNoteFilePath resolves to notebook root`
- `relative mode with a sub-dir note resolves relative to that dir`
- `shortest mode: bare filename resolves to the unique matching note`
- `shortest mode: bare filename with multiple matches picks shortest path`
- `shortest mode: bare filename with ties prefers same-dir note`
- `shortest mode: no match falls back to relative resolution`
- `shortest mode: partial path [[summary/report]] matches by suffix`
- `shortest mode: exact notebook-relative path resolves unambiguously`
- `shortest mode: ambiguous partial path picks shortest candidate`
- `shortest mode: partial path no match falls back to relative resolution`

All 10 pass. Existing `test/wikilink.test.ts` (21 tests) continues to pass unchanged.