### PR TITLE
fix(esm): add .js extension to bit-field/lib/render import

### DIFF
--- a/src/renderers/bitfield.ts
+++ b/src/renderers/bitfield.ts
@@ -1,7 +1,7 @@
 import { escape } from 'html-escaper';
 import onml from 'onml';
 import { JsonObject } from 'type-fest';
-import render from 'bit-field/lib/render';
+import render from 'bit-field/lib/render.js';
 import { interpretJS } from '../utility';
 
 export async function renderBitfield(code: string, options: JsonObject) {

--- a/src/types/modules.d.ts
+++ b/src/types/modules.d.ts
@@ -64,7 +64,7 @@ declare module 'onml' {
   export function stringify(arr: unknown[]): string;
 }
 
-declare module 'bit-field/lib/render' {
+declare module 'bit-field/lib/render.js' {
   function render(reg: unknown, options: unknown): unknown[];
   export default render;
 }

--- a/test/bitfield.test.ts
+++ b/test/bitfield.test.ts
@@ -1,0 +1,24 @@
+import { renderBitfield } from '../src/renderers/bitfield';
+
+describe('Bitfield renderer', () => {
+  it('renders a basic bit-field definition to HTML', async () => {
+    const code = `[
+      { "name": "IPO",   "bits": 8, "attr": "RO" },
+      { "bits": 7 },
+      { "name": "BRK",   "bits": 5, "attr": "RW", "type": 4 },
+      { "name": "CPK",   "bits": 1 },
+      { "name": "Clear", "bits": 3 },
+      { "bits": 8 }
+    ]`;
+    const result = await renderBitfield(code, {});
+    expect(typeof result).toBe('string');
+    expect(result).toContain('<svg');
+    expect(result).toContain('</svg>');
+  });
+
+  it('returns escaped error markup on invalid input', async () => {
+    const result = await renderBitfield('not-valid-json[', {});
+    expect(typeof result).toBe('string');
+    expect(result).toContain('<pre class="language-text">');
+  });
+});


### PR DESCRIPTION
## Summary

The ESM bundle (`out/esm/index.mjs`) emits `require('bit-field/lib/render')` for the externalized `bit-field` dependency. Under Node's strict ESM resolver this throws `ERR_MODULE_NOT_FOUND` because `bit-field@^1.9.0` ships as plain CommonJS without an `exports` map — deep imports require the explicit `.js` extension under ESM.

This is a one-character source fix; both CJS and ESM bundles still resolve correctly because explicit `.js` paths work identically under both module systems.

## Reproduction (before the fix)

```bash
$ node --input-type=module -e "
  import('crossnote').then(m => m.Notebook.init({ notebookPath: '/tmp' }))
    .then(nb => nb.getNoteMarkdownEngine('x.md').chromeExport({ fileType: 'pdf' }))
"
```

When a notebook contains a `bitfield` / `bit-field` fenced code block, the bundled `renderBitfield` path throws:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module 'bit-field/lib/render' imported from .../crossnote/out/esm/index.mjs
```

After this PR, the import resolves cleanly under ESM (and continues to resolve under CJS).

## Changes

- `src/renderers/bitfield.ts:4` — `import render from 'bit-field/lib/render'` → `'bit-field/lib/render.js'`
- `src/types/modules.d.ts:67` — matching `declare module 'bit-field/lib/render.js'` so TypeScript still picks up the ambient declaration
- `test/bitfield.test.ts` — small regression test exercising `renderBitfield` so the import path is covered by CI

## Verification

- `pnpm build` produces `out/esm/index.mjs` containing the corrected `bit-field/lib/render.js` reference (verified via `grep`)
- `node --input-type=module -e "import('./out/esm/index.mjs').then(m => console.log(Object.keys(m)))"` resolves the bundle cleanly
- `pnpm check` (eslint + prettier + tsc) passes
- Full `jest` suite: 400 passed, identical to the pre-change baseline on `develop` (3 pre-existing test failures in unrelated files — `colon-fence`, `tag`, `wikilink-embed` — are not touched)

## Context

Encountered while running crossnote inside an MCP server (`mcp-printer`) that dynamically imports `crossnote` only when markdown rendering is requested. The runtime crash is otherwise hidden behind a feature flag in that project.