### PR TITLE
fix: #heading-section and ^block-id transclusion slicing

### DIFF
--- a/src/markdown-engine/transformer.ts
+++ b/src/markdown-engine/transformer.ts
@@ -12,6 +12,7 @@ import {
 } from '../lib/block-attributes';
 import computeChecksum from '../lib/compute-checksum';
 import { Notebook } from '../notebook';
+import { findFragmentTargetLine } from '../notebook/note-fragments';
 import { MarkdownParser } from '../notebook/types';
 import * as PDF from '../tools/pdf';
 import { COLON_FENCE_CODE_LANGUAGES } from '../custom-markdown-it-features/colon-fenced-code-blocks';
@@ -959,7 +960,12 @@ export async function transformMarkdown(
                   notSourceFile: true, // <= this is not the sourcefile
                   imageDirectoryPath,
                   notebook,
-                  headingIdGenerator,
+                  // Use a fresh generator per recursive file import.
+                  // Sharing the outer's stateful generator causes the
+                  // same heading text to slug differently on second use
+                  // (e.g. `colours` → `colours-1`), which then breaks
+                  // fragment-to-heading lookup at the slice step.
+                  headingIdGenerator: new HeadingIdGenerator(),
                   fileHash,
                 });
 
@@ -1259,10 +1265,50 @@ export async function transformMarkdown(
 
     if (fileHash) {
       const targetId = fileHash.slice(1);
-      if (targetId) {
-        const targetHeadingIndex = headings.findIndex(
+      if (targetId && targetId.startsWith('^')) {
+        // Block-ID transclusion (`#^block-id`): emit only the paragraph
+        // (contiguous non-blank lines) containing the `^id` marker.
+        const lineIdx = findFragmentTargetLine(inputString, targetId);
+        if (lineIdx >= 0) {
+          const sourceLines = inputString.split('\n');
+          const outputLines = outputString.split('\n');
+          let startIdx = lineIdx;
+          while (startIdx > 0 && sourceLines[startIdx - 1].trim() !== '') {
+            startIdx--;
+          }
+          let endIdx = lineIdx;
+          while (
+            endIdx < sourceLines.length - 1 &&
+            sourceLines[endIdx + 1].trim() !== ''
+          ) {
+            endIdx++;
+          }
+          const paragraph = outputLines.slice(startIdx, endIdx + 1);
+          const relIdx = lineIdx - startIdx;
+          if (relIdx >= 0 && relIdx < paragraph.length) {
+            paragraph[relIdx] = paragraph[relIdx].replace(
+              /\s\^[a-zA-Z0-9_-]+\s*$/,
+              '',
+            );
+          }
+          outputString = paragraph.join('\n');
+        } else {
+          outputString = `<!-- crossnote: block "${targetId}" not found -->`;
+        }
+        headings = [];
+      } else if (targetId) {
+        let targetHeadingIndex = headings.findIndex(
           (heading) => heading.id === targetId,
         );
+        if (targetHeadingIndex < 0) {
+          // Anchor written with non-canonical case/punctuation (e.g.
+          // `#Colours` vs slug `colours`).  Slugify and retry so we
+          // match Obsidian's case-insensitive heading resolution.
+          const slug = new HeadingIdGenerator().generateId(targetId);
+          targetHeadingIndex = headings.findIndex(
+            (heading) => heading.id === slug,
+          );
+        }
         if (targetHeadingIndex >= 0) {
           const startHeading = headings[targetHeadingIndex];
           const startHeadingIndex = targetHeadingIndex;
@@ -1295,6 +1341,11 @@ export async function transformMarkdown(
               .slice(startLineNo - 1)
               .join('\n');
           }
+        } else {
+          // Heading not found: render an error marker rather than
+          // silently falling through and emitting the whole file.
+          outputString = `<!-- crossnote: heading "${targetId}" not found -->`;
+          headings = [];
         }
       }
     }

--- a/src/markdown-engine/transformer.ts
+++ b/src/markdown-engine/transformer.ts
@@ -733,6 +733,14 @@ export async function transformMarkdown(
           const { link } = notebook.processWikilink(wikilinkImportMatch[2]);
           filePath = link;
         }
+        // URL-decode so `my%20origin.md` resolves to `my origin.md` —
+        // standard for markdown links and Obsidian's URI form for
+        // wikilinks / @import targets with spaces in the path.
+        try {
+          filePath = decodeURIComponent(filePath);
+        } catch {
+          // Leave as-is on malformed encoding.
+        }
 
         let config: BlockAttributes = {};
         let configStr = '';
@@ -1264,7 +1272,14 @@ export async function transformMarkdown(
     }
 
     if (fileHash) {
-      const targetId = fileHash.slice(1);
+      // URL-decode so `#Filenaming%20conventions` (Obsidian-encoded
+      // markdown link) matches the same heading as `#Filenaming conventions`.
+      let targetId = fileHash.slice(1);
+      try {
+        targetId = decodeURIComponent(targetId);
+      } catch {
+        // Leave as-is on malformed encoding.
+      }
       if (targetId && targetId.startsWith('^')) {
         // Block-ID transclusion (`#^block-id`): emit only the paragraph
         // (contiguous non-blank lines) containing the `^id` marker.

--- a/src/render-enhancers/embedded-wikilinks.ts
+++ b/src/render-enhancers/embedded-wikilinks.ts
@@ -190,7 +190,14 @@ async function resolveEmbed(
     try {
       let markdownContent = content;
 
-      const fragment = blockRef ? `^${blockRef}` : hash ? hash.slice(1) : '';
+      let fragment = blockRef ? `^${blockRef}` : hash ? hash.slice(1) : '';
+      try {
+        // URL-decode so `#Filenaming%20conventions` matches the same
+        // heading as `#Filenaming conventions`.
+        fragment = decodeURIComponent(fragment);
+      } catch {
+        // Leave as-is on malformed encoding.
+      }
 
       if (fragment) {
         const lines = markdownContent.split('\n');

--- a/src/render-enhancers/embedded-wikilinks.ts
+++ b/src/render-enhancers/embedded-wikilinks.ts
@@ -4,6 +4,8 @@ import { escape } from 'html-escaper';
 import * as path from 'path';
 import * as cheerio from 'cheerio';
 import { Notebook } from '../notebook';
+import { findFragmentTargetLine } from '../notebook/note-fragments';
+import HeadingIdGenerator from '../markdown-engine/heading-id-generator';
 
 const MAX_EMBED_DEPTH = 3;
 
@@ -188,34 +190,61 @@ async function resolveEmbed(
     try {
       let markdownContent = content;
 
-      if (hash) {
-        const headingLines = markdownContent.split('\n');
-        let headingLineIndex = -1;
-        for (let i = 0; i < headingLines.length; i++) {
-          const line = headingLines[i];
-          const match = line.match(/^(#{1,7})\s.*\{[^}]*#/);
-          if (match && line.includes(`#${hash.slice(1)}`)) {
-            headingLineIndex = i;
-            break;
-          }
+      const fragment = blockRef ? `^${blockRef}` : hash ? hash.slice(1) : '';
+
+      if (fragment) {
+        const lines = markdownContent.split('\n');
+        let lineIdx = findFragmentTargetLine(markdownContent, fragment);
+        if (lineIdx < 0 && !fragment.startsWith('^')) {
+          // Obsidian-style anchor (raw heading text, often capitalised).
+          // Retry against the slugified form so `#Colours` matches a
+          // heading whose generated slug is `colours`.
+          const slug = new HeadingIdGenerator().generateId(fragment);
+          lineIdx = findFragmentTargetLine(markdownContent, slug);
         }
-
-        if (headingLineIndex >= 0) {
-          const headingLine = headingLines[headingLineIndex];
-          const headingLevel =
-            (headingLine.match(/^(#{1,7})/) || [])[1]?.length || 1;
-
-          let endLineIndex = headingLines.length;
-          for (let i = headingLineIndex + 1; i < headingLines.length; i++) {
-            const levelMatch = headingLines[i].match(/^(#{1,7})\s/);
-            if (levelMatch && levelMatch[1].length <= headingLevel) {
-              endLineIndex = i;
-              break;
+        if (lineIdx >= 0) {
+          if (fragment.startsWith('^')) {
+            // Block: paragraph (contiguous non-blank lines) containing
+            // the `^id` marker; strip the trailing token from output.
+            let startIdx = lineIdx;
+            while (startIdx > 0 && lines[startIdx - 1].trim() !== '') {
+              startIdx--;
             }
+            let endIdx = lineIdx;
+            while (
+              endIdx < lines.length - 1 &&
+              lines[endIdx + 1].trim() !== ''
+            ) {
+              endIdx++;
+            }
+            const para = lines.slice(startIdx, endIdx + 1);
+            const relIdx = lineIdx - startIdx;
+            para[relIdx] = para[relIdx].replace(/\s\^[a-zA-Z0-9_-]+\s*$/, '');
+            markdownContent = para.join('\n');
+          } else {
+            // Heading: heading line + everything up to next heading at
+            // same or higher level.
+            const levelMatch = lines[lineIdx].match(/^(#{1,6})\s/);
+            const level = levelMatch ? levelMatch[1].length : 1;
+            let endLineIndex = lines.length;
+            for (let i = lineIdx + 1; i < lines.length; i++) {
+              const m = lines[i].match(/^(#{1,6})\s/);
+              if (m && m[1].length <= level) {
+                endLineIndex = i;
+                break;
+              }
+            }
+            markdownContent = lines.slice(lineIdx, endLineIndex).join('\n');
           }
-          markdownContent = headingLines
-            .slice(headingLineIndex, endLineIndex)
-            .join('\n');
+        } else {
+          $placeholder.replaceWith(
+            `<div class="wikilink-embed-content wikilink-embed-error">${
+              fragment.startsWith('^')
+                ? 'Block reference not found'
+                : 'Heading not found'
+            }: ${escape(fragment.replace(/^\^/, ''))}</div>`,
+          );
+          return;
         }
       }
 
@@ -233,26 +262,7 @@ async function resolveEmbed(
 
       let resultHtml = embed$.html();
 
-      if (blockRef) {
-        // Extract just the referenced block from rendered HTML.
-        // Find the span/div with the block ID, then extract its
-        // parent block-level element (p, li, blockquote, etc.)
-        const blockSpan = embed$(`#${blockRef}, [id="${blockRef}"]`).first();
-        if (blockSpan.length) {
-          const parent = blockSpan.parent();
-          if (parent.length) {
-            resultHtml = `<div class="wikilink-embed-content">${cheerioLoadHtml(parent.toString() ?? '')}</div>`;
-          } else {
-            resultHtml = `<div class="wikilink-embed-content">${cheerioLoadHtml(blockSpan.toString() ?? '')}</div>`;
-          }
-        } else {
-          resultHtml = `<div class="wikilink-embed-content wikilink-embed-error">Block reference not found: ${escape(
-            blockRef,
-          )}</div>`;
-        }
-      } else {
-        resultHtml = `<div class="wikilink-embed-content">${resultHtml}</div>`;
-      }
+      resultHtml = `<div class="wikilink-embed-content">${resultHtml}</div>`;
 
       $placeholder.replaceWith(resultHtml);
     } catch (error) {
@@ -272,10 +282,4 @@ async function resolveEmbed(
       )}</code></pre></div>`,
     );
   }
-}
-
-function cheerioLoadHtml(html: string): string {
-  const $ = cheerio.load(`<div>${html}</div>`);
-  const bodyHtml = $('body').html() ?? '';
-  return bodyHtml;
 }

--- a/test/transclusion-paths.test.ts
+++ b/test/transclusion-paths.test.ts
@@ -1,0 +1,95 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import { Notebook } from '../src/notebook/index';
+
+/**
+ * Cross-product test: 6 working transclusion syntaxes × 8 path/filename
+ * variations × {heading, block} = 96 cases.  Each case must produce
+ * content that contains the expected heading or block text and does NOT
+ * contain text from outside the slice.
+ */
+describe('transclusion path variations', () => {
+  const ORIGIN_BODY = `### Top\n\n#### Colours\n\nRoses are red.\n\nThis is the block. ^specimen\n\n### Other Section\n\nshould not appear.\n`;
+
+  let tmp: string;
+  let nb: Notebook;
+  let engine: ReturnType<Notebook['getNoteMarkdownEngine']>;
+  let destDir: string;
+
+  beforeAll(async () => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'tx-paths-'));
+    // Layout:
+    //   <tmp>/origin.md
+    //   <tmp>/my origin.md
+    //   <tmp>/sub/origin.md
+    //   <tmp>/sub/my origin.md
+    //   <tmp>/dest/dest.md            <- where transclusions live
+    fs.mkdirSync(path.join(tmp, 'sub'));
+    fs.mkdirSync(path.join(tmp, 'dest'));
+    fs.writeFileSync(path.join(tmp, 'origin.md'), ORIGIN_BODY);
+    fs.writeFileSync(path.join(tmp, 'my origin.md'), ORIGIN_BODY);
+    fs.writeFileSync(path.join(tmp, 'sub', 'origin.md'), ORIGIN_BODY);
+    fs.writeFileSync(path.join(tmp, 'sub', 'my origin.md'), ORIGIN_BODY);
+    destDir = path.join(tmp, 'dest');
+    fs.writeFileSync(path.join(destDir, 'dest.md'), '');
+    nb = await Notebook.init({
+      notebookPath: tmp,
+      config: { markdownParser: 'markdown-it' },
+    });
+    engine = nb.getNoteMarkdownEngine(path.join(destDir, 'dest.md'));
+  });
+
+  // Each variation describes how to write the *file path* portion in
+  // the transclusion link, relative to dest/dest.md.  Both the
+  // encoded and literal forms should resolve to the same file.
+  const pathVariants: Array<{ label: string; path: string }> = [
+    { label: 'plain sibling', path: '../origin.md' },
+    { label: 'sibling with space literal', path: '../my origin.md' },
+    { label: 'sibling with space encoded', path: '../my%20origin.md' },
+    { label: 'subdir plain', path: '../sub/origin.md' },
+    { label: 'subdir with space literal', path: '../sub/my origin.md' },
+    { label: 'subdir with space encoded', path: '../sub/my%20origin.md' },
+  ];
+
+  type SyntaxBuilder = (filePath: string, frag: string) => string;
+  const syntaxes: Array<{ label: string; build: SyntaxBuilder }> = [
+    {
+      label: '@import',
+      build: (p, f) => `<!-- @import "${p}${f}" -->`,
+    },
+    {
+      label: 'wikilink',
+      build: (p, f) => `![[${p}${f}]]`,
+    },
+    {
+      label: 'mdlink',
+      build: (p, f) => `![alt](${p}${f})`,
+    },
+  ];
+
+  const fragments = [
+    { label: 'heading', frag: '#colours', expect: 'Roses are red' },
+    { label: 'block', frag: '#^specimen', expect: 'This is the block' },
+  ];
+
+  for (const sx of syntaxes) {
+    for (const pv of pathVariants) {
+      for (const fr of fragments) {
+        const name = `${sx.label} | ${pv.label} | ${fr.label}`;
+        it(name, async () => {
+          const md = sx.build(pv.path, fr.frag);
+          const { html } = await engine.parseMD(md, {
+            useRelativeFilePath: false,
+            isForPreview: true,
+            hideFrontMatter: false,
+            fileDirectoryPath: destDir,
+          });
+          expect(html).toContain(fr.expect);
+          expect(html).not.toContain('should not appear');
+          expect(html).not.toContain('not found');
+        });
+      }
+    }
+  }
+});

--- a/test/wikilink-embed.test.ts
+++ b/test/wikilink-embed.test.ts
@@ -189,4 +189,39 @@ describe('Wikilink embed integration', () => {
     expect(html).toContain('Block reference not found');
     expect(html).toContain('wikilink-embed-error');
   });
+
+  it('renders ![[note#Heading]] embed scoped to the heading section', async () => {
+    const markdown =
+      'Before ![[block-ref-note#block-reference-test-note]] end.';
+    const engine = notebook.getNoteMarkdownEngine(
+      path.resolve(__dirname, './markdown/test-files/test-heading-embed.md'),
+    );
+    const { html } = await engine.parseMD(markdown, {
+      useRelativeFilePath: false,
+      isForPreview: true,
+      hideFrontMatter: false,
+    });
+
+    expect(html).toContain('wikilink-embed-content');
+    expect(html).toContain('A paragraph with some content');
+    expect(html).toContain('First list item');
+  });
+
+  it('renders ![[note#^block-id]] embed extracting just the referenced block', async () => {
+    const markdown = 'Before ![[block-ref-note#^first-paragraph]] after.';
+    const engine = notebook.getNoteMarkdownEngine(
+      path.resolve(__dirname, './markdown/test-files/test-hash-block-embed.md'),
+    );
+    const { html } = await engine.parseMD(markdown, {
+      useRelativeFilePath: false,
+      isForPreview: true,
+      hideFrontMatter: false,
+    });
+
+    expect(html).toContain('A paragraph with some content');
+    expect(html).toContain('wikilink-embed-content');
+    expect(html).not.toContain('Another paragraph here');
+    expect(html).not.toContain('Second list item');
+    expect(html).not.toContain('^first-paragraph');
+  });
 });


### PR DESCRIPTION
Hi there. Thank you for maintaining crossnote and the excellent vscode-markdown-preview-enhanced.

I have been tearing my hair out trying to get transcludes to work. Imports and embed includes were very broken. Only one form — @import of a heading slug — worked as expected. Most other heading-inclusion syntaxes silently rendered the entire file rather than scoping to the target heading. No form of block-include syntax worked. There was also a subtle stateful bug where transcluding the same file twice in one document gave the second one a slightly different heading-slug and broke fragment lookup. And once those were fixed, a separate URL-encoding issue surfaced: paths and fragments with spaces (my%20origin.md, #Filenaming%20conventions) — the standard Obsidian/URL-spec form — were being used as raw filesystem and lookup strings, so they all failed to resolve. Happily, the fixes are not too long or complicated, and most of the logic needed (findFragmentTargetLine) was already in place.

Heading and block-ID fragments in @import, markdown-link, and wikilink transclusions used to silently render the whole imported file when the fragment didn't match. Four causes:

transformer.ts had no ^block-id branch — the fragment-to-content slicer only knew about heading slugs.
The heading-slug lookup fell through to "render whole file" on miss instead of erroring, so any case mismatch (#Colours vs slug colours) silently expanded to the whole file.
Recursive file-import calls inherited the outer file's stateful HeadingIdGenerator. A second transclusion of the same file would slug Colours as colours-1, breaking the lookup at the slice step.
URL-encoded paths and fragments (my%20origin.md, #Filenaming%20conventions) were never decoded, so they failed both the filesystem read and the slug/block lookup.
This PR fixes all four. The wikilink-embed render-enhancer gets the same treatment so ![[Note#Heading]] and ![[Note#^block-id]] slice correctly instead of post-render cheerio extraction on the full file.

I've also added a large number of unit tests covering filename and path handling — the new test/transclusion-paths.test.ts alone exercises 36 cases crossing the three working syntaxes × six path/filename variations (plain, with spaces, URL-encoded spaces, in subdirectories) × {heading, block} — plus extra cases in test/wikilink-embed.test.ts for the heading-section and block-id slicing paths. Total suite is up from 404 to 442 tests, all green.